### PR TITLE
Add docker-compose configuration for mitbot service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy
+
+permissions:
+  contents: read
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency:
+      group: deploy
+    steps:
+      - name: Deploy to DigitalOcean Droplet
+        uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f
+        with:
+          host: ${{secrets.HOST}}
+          username: ${{secrets.USERNAME}}
+          key: ${{secrets.SSH_KEY}}
+          port: ${{secrets.PORT}}
+          script: |
+            cd make-it-public
+            git pull
+            docker compose pull
+            export BOT_TOKEN=${{ secrets.BOT_TOKEN }}
+            export MIT_URL=${{ secrets.MIT_URL }}
+            export REPO_REDIS_ADDR=${{ secrets.REPO_REDIS_ADDR }}
+            export NETWORK_NAME=${{ env.MIT_NETWORK }}
+            docker stack deploy -c docker-compose.yml makeitpublic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  mitbot:
+    build:
+      context: .
+    image: "ghcr.io/ksysoev/make-it-public-tgbot:main"
+    restart: unless-stopped
+    container_name: mitbot
+    environment:
+      - BOT_TOKEN=${BOT_TOKEN}
+      - MIT_URL=${MIT_URL}
+      - MIT_DEFAULT_TTL=604800
+      - REPO_REDIS_ADDR=${REPO_REDIS_ADDR}
+      - REPO_KEY_PREFIX=MITTGBOT::
+    command: ["run"]
+    depends_on:
+      - redis
+
+networks:
+  default:
+    external: true
+    name: ${NETWORK_NAME:-mit-network}


### PR DESCRIPTION
This pull request introduces a deployment workflow for the project and updates the Docker Compose configuration to support the deployment process. The key changes include creating a GitHub Actions workflow for deployment and defining the necessary services and environment variables in the `docker-compose.yml` file.

### Deployment Workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R35): Added a new GitHub Actions workflow named "Deploy" that triggers on version tag pushes or manual dispatch. It uses the `ssh-action` to deploy the application to a DigitalOcean Droplet, pulling the latest code and updating the Docker stack with environment variables from GitHub secrets.

### Docker Compose Configuration:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R21): Added a `mitbot` service with build context, image, restart policy, container name, and environment variables. The service depends on `redis` and runs with an external Docker network, configurable via the `NETWORK_NAME` environment variable.### Summary
Introduced a `docker-compose.yml` file for the `mitbot` service to streamline deployment and ensure consistent setup.

### Changes Made
- Added `docker-compose.yml` file with configuration for the `mitbot` service.
- Includes environment variables, networking, and service dependencies.
