### PR TITLE
Update deployment workflow to correct service name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,4 @@ jobs:
             export MIT_URL=${{ secrets.MIT_URL }}
             export REPO_REDIS_ADDR=${{ secrets.REPO_REDIS_ADDR }}
             export NETWORK_NAME=${{ env.MIT_NETWORK }}
-            docker stack deploy -c docker-compose.yml makeitpublic
+            docker stack deploy -c docker-compose.yml mitbot


### PR DESCRIPTION
The deployment workflow has been updated to rename the docker stack deployment target from "makeitpublic" to "mitbot". This change ensures the proper service is deployed during the automated processes. No functional changes were made apart from renaming the target in the workflow.