### PR TITLE
Update workflow to use correct deployment script directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
           key: ${{secrets.SSH_KEY}}
           port: ${{secrets.PORT}}
           script: |
-            cd make-it-public
+            cd make-it-public-tgbot
             git pull
             docker compose pull
             export BOT_TOKEN=${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
Renamed the deployment directory in the GitHub Actions workflow from `make-it-public` to `make-it-public-tgbot` to target the correct location for pulling updates and deploying changes.