### PR TITLE
Set REPO_KEY_PREFIX value in quotes in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - MIT_URL=${MIT_URL}
       - MIT_DEFAULT_TTL=604800
       - REPO_REDIS_ADDR=${REPO_REDIS_ADDR}
-      - REPO_KEY_PREFIX=MITTGBOT::
+      - "REPO_KEY_PREFIX=MITTGBOT::"
     command: ["run"]
     depends_on:
       - redis


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to place `REPO_KEY_PREFIX` value in quotes. This change ensures correct interpretation by the YAML parser, prevents potential misconfigurations, and improves compatibility.