### PR TITLE
Enhance Telegram bot with token revocation and tests

### DIFF
--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -31,6 +31,7 @@ type Config struct {
 
 type TokenService interface {
 	CreateToken(ctx context.Context, userID string) (*core.APIToken, error)
+	RevokeToken(ctx context.Context, userID string) error
 }
 
 type Service struct {

--- a/pkg/bot/handlers.go
+++ b/pkg/bot/handlers.go
@@ -18,6 +18,7 @@ const (
 	tokenCreatedMessage   = "🔑 Your New API Token\n\n%s\n\n⏱ Valid until: %s\n\nKeep this token secure and don't share it with others."
 	tokenExistsMessage    = "⚠️ You already have an active API token. You can create a new one after your current token expires."
 	notCommandMessage     = "I can only respond to commands. Try /help to see what I can do."
+	tokenRevokedMessage   = "🔒 Your API token has been successfully revoked.\n\nYou can create a new one using /new_token command."
 )
 
 // Handler defines the interface for processing and responding to incoming messages in a Telegram bot context.
@@ -78,6 +79,12 @@ func (s *Service) handleCommand(ctx context.Context, msg *tgbotapi.Message) (tgb
 
 			return message, nil
 		}
+	case "revoke_token":
+		if err := s.tokenSvc.RevokeToken(ctx, fmt.Sprintf("%d", msg.From.ID)); err != nil {
+			return tgbotapi.MessageConfig{}, fmt.Errorf("failed to revoke token: %w", err)
+		}
+
+		return tgbotapi.NewMessage(msg.Chat.ID, tokenRevokedMessage), nil
 	default:
 		return tgbotapi.NewMessage(msg.Chat.ID, unknownCommandMessage), nil
 	}

--- a/pkg/bot/handlers_test.go
+++ b/pkg/bot/handlers_test.go
@@ -1,0 +1,343 @@
+package bot
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/ksysoev/make-it-public-tgbot/pkg/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupHandler(t *testing.T) {
+	// Create a service with mocked dependencies
+	mockTokenSvc := NewMockTokenService(t)
+	svc := &Service{
+		token:    "test-token",
+		tg:       NewMocktgClient(t),
+		tokenSvc: mockTokenSvc,
+	}
+
+	// Call setupHandler
+	handler := svc.setupHandler()
+
+	// Verify that the handler is not nil
+	assert.NotNil(t, handler, "Handler should not be nil")
+}
+
+func TestHandleCommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		setupMocks func(mockTokenSvc *MockTokenService)
+		chatID     int64
+		userID     int64
+		wantText   string
+		wantErr    bool
+	}{
+		{
+			name:    "start command",
+			command: "start",
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				// No mocks needed for start command
+			},
+			chatID:   123,
+			userID:   456,
+			wantText: welcomeMessage,
+			wantErr:  false,
+		},
+		{
+			name:    "help command",
+			command: "help",
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				// No mocks needed for help command
+			},
+			chatID:   123,
+			userID:   456,
+			wantText: helpMessage,
+			wantErr:  false,
+		},
+		{
+			name:    "new_token command - success",
+			command: "new_token",
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				token := &core.APIToken{
+					KeyID:     "key123",
+					Token:     "token123",
+					ExpiresIn: 3600,
+				}
+				mockTokenSvc.EXPECT().CreateToken(mock.Anything, "456").Return(token, nil)
+			},
+			chatID:  123,
+			userID:  456,
+			wantErr: false,
+		},
+		{
+			name:    "new_token command - token exists",
+			command: "new_token",
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				mockTokenSvc.EXPECT().CreateToken(mock.Anything, "456").Return(nil, core.ErrMaxTokensExceeded)
+			},
+			chatID:   123,
+			userID:   456,
+			wantText: tokenExistsMessage,
+			wantErr:  false,
+		},
+		{
+			name:    "new_token command - error",
+			command: "new_token",
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				mockTokenSvc.EXPECT().CreateToken(mock.Anything, "456").Return(nil, errors.New("some error"))
+			},
+			chatID:  123,
+			userID:  456,
+			wantErr: true,
+		},
+		{
+			name:    "revoke_token command - success",
+			command: "revoke_token",
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				mockTokenSvc.EXPECT().RevokeToken(mock.Anything, "456").Return(nil)
+			},
+			chatID:   123,
+			userID:   456,
+			wantText: tokenRevokedMessage,
+			wantErr:  false,
+		},
+		{
+			name:    "revoke_token command - error",
+			command: "revoke_token",
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				mockTokenSvc.EXPECT().RevokeToken(mock.Anything, "456").Return(errors.New("revoke error"))
+			},
+			chatID:  123,
+			userID:  456,
+			wantErr: true,
+		},
+		{
+			name:    "unknown command",
+			command: "unknown",
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				// No mocks needed for unknown command
+			},
+			chatID:   123,
+			userID:   456,
+			wantText: unknownCommandMessage,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a service with mocked dependencies
+			mockTokenSvc := NewMockTokenService(t)
+			svc := &Service{
+				token:    "test-token",
+				tg:       NewMocktgClient(t),
+				tokenSvc: mockTokenSvc,
+			}
+
+			// Setup mocks
+			tt.setupMocks(mockTokenSvc)
+
+			// Create a message with the command
+			msg := &tgbotapi.Message{
+				Text: "/" + tt.command,
+				Entities: []tgbotapi.MessageEntity{
+					{
+						Type:   "bot_command",
+						Offset: 0,
+						Length: len(tt.command) + 1,
+					},
+				},
+				Chat: &tgbotapi.Chat{
+					ID: tt.chatID,
+				},
+				From: &tgbotapi.User{
+					ID: tt.userID,
+				},
+			}
+
+			// Call handleCommand
+			resp, err := svc.handleCommand(context.Background(), msg)
+
+			// Check error
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Check response
+			if tt.wantText != "" {
+				assert.Equal(t, tt.wantText, resp.Text)
+			}
+
+			// For new_token success, check that the response contains token information
+			if tt.command == "new_token" && !tt.wantErr && tt.wantText == "" {
+				assert.Contains(t, resp.Text, "Your New API Token")
+				assert.Contains(t, resp.Text, "token123")
+				assert.Contains(t, resp.Text, "Valid until:")
+			}
+		})
+	}
+}
+
+func TestHandleMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		message    *tgbotapi.Message
+		setupMocks func(mockTokenSvc *MockTokenService)
+		wantText   string
+		wantErr    bool
+	}{
+		{
+			name: "command message",
+			message: &tgbotapi.Message{
+				Text: "/start",
+				Entities: []tgbotapi.MessageEntity{
+					{
+						Type:   "bot_command",
+						Offset: 0,
+						Length: 6,
+					},
+				},
+				Chat: &tgbotapi.Chat{
+					ID: 123,
+				},
+				From: &tgbotapi.User{
+					ID: 456,
+				},
+			},
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				// No mocks needed for start command
+			},
+			wantText: welcomeMessage,
+			wantErr:  false,
+		},
+		{
+			name: "non-command message",
+			message: &tgbotapi.Message{
+				Text: "hello",
+				Chat: &tgbotapi.Chat{
+					ID: 123,
+				},
+				From: &tgbotapi.User{
+					ID: 456,
+				},
+			},
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				// No mocks needed for non-command message
+			},
+			wantText: notCommandMessage,
+			wantErr:  false,
+		},
+		{
+			name: "command with error",
+			message: &tgbotapi.Message{
+				Text: "/new_token",
+				Entities: []tgbotapi.MessageEntity{
+					{
+						Type:   "bot_command",
+						Offset: 0,
+						Length: 10,
+					},
+				},
+				Chat: &tgbotapi.Chat{
+					ID: 123,
+				},
+				From: &tgbotapi.User{
+					ID: 456,
+				},
+			},
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				mockTokenSvc.EXPECT().CreateToken(mock.Anything, "456").Return(nil, errors.New("some error"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a service with mocked dependencies
+			mockTokenSvc := NewMockTokenService(t)
+			svc := &Service{
+				token:    "test-token",
+				tg:       NewMocktgClient(t),
+				tokenSvc: mockTokenSvc,
+			}
+
+			// Setup mocks
+			tt.setupMocks(mockTokenSvc)
+
+			// Call Handle
+			resp, err := svc.Handle(context.Background(), tt.message)
+
+			// Check error
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Check response
+			assert.Equal(t, tt.wantText, resp.Text)
+		})
+	}
+}
+
+// TestHandleCommandTimeFormat tests that the time format in the token message is correct
+func TestHandleCommandTimeFormat(t *testing.T) {
+	// Create a service with mocked dependencies
+	mockTokenSvc := NewMockTokenService(t)
+	svc := &Service{
+		token:    "test-token",
+		tg:       NewMocktgClient(t),
+		tokenSvc: mockTokenSvc,
+	}
+
+	// Setup mock for CreateToken
+	token := &core.APIToken{
+		KeyID:     "key123",
+		Token:     "token123",
+		ExpiresIn: 3600, // 1 hour
+	}
+	mockTokenSvc.EXPECT().CreateToken(mock.Anything, "456").Return(token, nil)
+
+	// Create a message with the new_token command
+	msg := &tgbotapi.Message{
+		Text: "/new_token",
+		Entities: []tgbotapi.MessageEntity{
+			{
+				Type:   "bot_command",
+				Offset: 0,
+				Length: 10,
+			},
+		},
+		Chat: &tgbotapi.Chat{
+			ID: 123,
+		},
+		From: &tgbotapi.User{
+			ID: 456,
+		},
+	}
+
+	// Call handleCommand
+	resp, err := svc.handleCommand(context.Background(), msg)
+	require.NoError(t, err)
+
+	// Check that the response contains the token and expiration time
+	assert.Contains(t, resp.Text, "token123")
+
+	// Calculate expected expiration time (approximately 1 hour from now)
+	expectedTime := time.Now().Add(time.Hour)
+
+	// Check that the response contains the year, month, and day
+	assert.Contains(t, resp.Text, expectedTime.Format("2006"))
+	assert.Contains(t, resp.Text, expectedTime.Format("01"))
+	assert.Contains(t, resp.Text, expectedTime.Format("02"))
+}

--- a/pkg/bot/token_service_mock.go
+++ b/pkg/bot/token_service_mock.go
@@ -83,6 +83,53 @@ func (_c *MockTokenService_CreateToken_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
+// RevokeToken provides a mock function with given fields: ctx, userID
+func (_m *MockTokenService) RevokeToken(ctx context.Context, userID string) error {
+	ret := _m.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RevokeToken")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, userID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockTokenService_RevokeToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RevokeToken'
+type MockTokenService_RevokeToken_Call struct {
+	*mock.Call
+}
+
+// RevokeToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *MockTokenService_Expecter) RevokeToken(ctx interface{}, userID interface{}) *MockTokenService_RevokeToken_Call {
+	return &MockTokenService_RevokeToken_Call{Call: _e.mock.On("RevokeToken", ctx, userID)}
+}
+
+func (_c *MockTokenService_RevokeToken_Call) Run(run func(ctx context.Context, userID string)) *MockTokenService_RevokeToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockTokenService_RevokeToken_Call) Return(_a0 error) *MockTokenService_RevokeToken_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockTokenService_RevokeToken_Call) RunAndReturn(run func(context.Context, string) error) *MockTokenService_RevokeToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockTokenService creates a new instance of MockTokenService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockTokenService(t interface {

--- a/pkg/core/mit_prov_mock.go
+++ b/pkg/core/mit_prov_mock.go
@@ -76,6 +76,52 @@ func (_c *MockMITProv_GenerateToken_Call) RunAndReturn(run func() (*APIToken, er
 	return _c
 }
 
+// RevokeToken provides a mock function with given fields: keyID
+func (_m *MockMITProv) RevokeToken(keyID string) error {
+	ret := _m.Called(keyID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RevokeToken")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(keyID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockMITProv_RevokeToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RevokeToken'
+type MockMITProv_RevokeToken_Call struct {
+	*mock.Call
+}
+
+// RevokeToken is a helper method to define mock.On call
+//   - keyID string
+func (_e *MockMITProv_Expecter) RevokeToken(keyID interface{}) *MockMITProv_RevokeToken_Call {
+	return &MockMITProv_RevokeToken_Call{Call: _e.mock.On("RevokeToken", keyID)}
+}
+
+func (_c *MockMITProv_RevokeToken_Call) Run(run func(keyID string)) *MockMITProv_RevokeToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockMITProv_RevokeToken_Call) Return(_a0 error) *MockMITProv_RevokeToken_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockMITProv_RevokeToken_Call) RunAndReturn(run func(string) error) *MockMITProv_RevokeToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockMITProv creates a new instance of MockMITProv. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockMITProv(t interface {

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -49,7 +49,7 @@ func (s *Service) CreateToken(ctx context.Context, userID string) (*APIToken, er
 		return nil, fmt.Errorf("failed to generate token: %w", err)
 	}
 
-	if err = s.repo.AddAPIKey(ctx, userID, token.KeyID, time.Duration(token.ExpiresIn)*time.Second); err != nil {
+	if err = s.repo.AddAPIKey(ctx, userID, token.KeyID, token.ExpiresIn); err != nil {
 		return nil, fmt.Errorf("failed to add API key: %w", err)
 	}
 

--- a/pkg/core/svc_test.go
+++ b/pkg/core/svc_test.go
@@ -116,7 +116,7 @@ func TestCreateToken(t *testing.T) {
 			repo.On("GetAPIKeys", mock.Anything, tt.userID).Return(tt.existingKeys, tt.getKeysErr)
 
 			if tt.expectAddKey {
-				repo.On("AddAPIKey", mock.Anything, tt.userID, tt.token.KeyID, time.Duration(tt.token.ExpiresIn)*time.Second).Return(tt.addKeyErr)
+				repo.On("AddAPIKey", mock.Anything, tt.userID, tt.token.KeyID, tt.token.ExpiresIn).Return(tt.addKeyErr)
 			}
 
 			if tt.existingKeys != nil && len(tt.existingKeys) == 0 {
@@ -136,6 +136,82 @@ func TestCreateToken(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedToken, token)
+			}
+
+			repo.AssertExpectations(t)
+			prov.AssertExpectations(t)
+		})
+	}
+}
+
+func TestRevokeToken(t *testing.T) {
+	tests := []struct {
+		name          string
+		userID        string
+		existingKeys  []string
+		getKeysErr    error
+		revokeProvErr error
+		revokeRepoErr error
+		expectedErr   string
+	}{
+		{
+			name:         "success",
+			userID:       "user123",
+			existingKeys: []string{"key123"},
+			getKeysErr:   nil,
+			expectedErr:  "",
+		},
+		{
+			name:         "no API keys found",
+			userID:       "user123",
+			existingKeys: []string{},
+			getKeysErr:   nil,
+			expectedErr:  "no API keys found for user user123",
+		},
+		{
+			name:         "multiple API keys found",
+			userID:       "user123",
+			existingKeys: []string{"key123", "key456"},
+			getKeysErr:   nil,
+			expectedErr:  "multiple API keys found for user user123, cannot revoke",
+		},
+		{
+			name:         "get keys error",
+			userID:       "user123",
+			existingKeys: nil,
+			getKeysErr:   errors.New("get keys error"),
+			expectedErr:  "failed to get API keys: get keys error",
+		},
+		{
+			name:          "revoke from repository error",
+			userID:        "user123",
+			existingKeys:  []string{"key123"},
+			revokeRepoErr: errors.New("revoke repository error"),
+			expectedErr:   "failed to remove API key from repository: revoke repository error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := NewMockUserRepo(t)
+			prov := NewMockMITProv(t)
+
+			repo.On("GetAPIKeys", mock.Anything, tt.userID).Return(tt.existingKeys, tt.getKeysErr)
+
+			if len(tt.existingKeys) == 1 {
+				prov.On("RevokeToken", tt.existingKeys[0]).Return(tt.revokeProvErr)
+				repo.On("RevokeToken", mock.Anything, tt.userID, tt.existingKeys[0]).Return(tt.revokeRepoErr)
+			}
+
+			svc := New(repo, prov)
+
+			err := svc.RevokeToken(context.Background(), tt.userID)
+
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedErr, err.Error())
+			} else {
+				assert.NoError(t, err)
 			}
 
 			repo.AssertExpectations(t)

--- a/pkg/core/svc_test.go
+++ b/pkg/core/svc_test.go
@@ -42,14 +42,14 @@ func TestCreateToken(t *testing.T) {
 			token: &APIToken{
 				KeyID:     "key123",
 				Token:     "token123",
-				ExpiresIn: 3600,
+				ExpiresIn: time.Hour,
 			},
 			generateErr: nil,
 			addKeyErr:   nil,
 			expectedToken: &APIToken{
 				KeyID:     "key123",
 				Token:     "token123",
-				ExpiresIn: 3600,
+				ExpiresIn: time.Hour,
 			},
 			expectedErr:  nil,
 			expectAddKey: true,
@@ -98,7 +98,7 @@ func TestCreateToken(t *testing.T) {
 			token: &APIToken{
 				KeyID:     "key123",
 				Token:     "token123",
-				ExpiresIn: 3600,
+				ExpiresIn: time.Hour,
 			},
 			generateErr:   nil,
 			addKeyErr:     errors.New("add key error"),

--- a/pkg/core/token.go
+++ b/pkg/core/token.go
@@ -1,7 +1,9 @@
 package core
 
+import "time"
+
 type APIToken struct {
 	KeyID     string
 	Token     string
-	ExpiresIn int64
+	ExpiresIn time.Duration
 }

--- a/pkg/core/user_repo_mock.go
+++ b/pkg/core/user_repo_mock.go
@@ -132,6 +132,54 @@ func (_c *MockUserRepo_GetAPIKeys_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
+// RevokeToken provides a mock function with given fields: ctx, userID, apiKeyID
+func (_m *MockUserRepo) RevokeToken(ctx context.Context, userID string, apiKeyID string) error {
+	ret := _m.Called(ctx, userID, apiKeyID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RevokeToken")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, userID, apiKeyID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockUserRepo_RevokeToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RevokeToken'
+type MockUserRepo_RevokeToken_Call struct {
+	*mock.Call
+}
+
+// RevokeToken is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+//   - apiKeyID string
+func (_e *MockUserRepo_Expecter) RevokeToken(ctx interface{}, userID interface{}, apiKeyID interface{}) *MockUserRepo_RevokeToken_Call {
+	return &MockUserRepo_RevokeToken_Call{Call: _e.mock.On("RevokeToken", ctx, userID, apiKeyID)}
+}
+
+func (_c *MockUserRepo_RevokeToken_Call) Run(run func(ctx context.Context, userID string, apiKeyID string)) *MockUserRepo_RevokeToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockUserRepo_RevokeToken_Call) Return(_a0 error) *MockUserRepo_RevokeToken_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockUserRepo_RevokeToken_Call) RunAndReturn(run func(context.Context, string, string) error) *MockUserRepo_RevokeToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockUserRepo creates a new instance of MockUserRepo. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockUserRepo(t interface {

--- a/pkg/prov/mit.go
+++ b/pkg/prov/mit.go
@@ -54,27 +54,45 @@ func (m *MIT) GenerateToken() (*core.APIToken, error) {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	resp, err := m.cl.Post(m.baseUrl+"/generateToken", "application/json", bytes.NewBuffer(jsonReq))
+	resp, err := m.cl.Post(m.baseUrl+"/token", "application/json", bytes.NewBuffer(jsonReq))
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusCreated {
 		return nil, fmt.Errorf("failed to generate token, status code: %d", resp.StatusCode)
 	}
 
-	var tokenResp generateTokenResponse
+	var tkn generateTokenResponse
 
-	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&tkn); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	token := core.APIToken{
-		Token:     tokenResp.Token,
-		KeyID:     tokenResp.KeyID,
-		ExpiresIn: tokenResp.TTL,
+	return &core.APIToken{
+		Token:     tkn.Token,
+		KeyID:     tkn.KeyID,
+		ExpiresIn: time.Duration(tkn.TTL) * time.Second,
+	}, nil
+}
+
+// RevokeToken sends a request to revoke an API token based on the provided key ID and returns an error if the request fails.
+func (m *MIT) RevokeToken(keyID string) error {
+	req, err := http.NewRequest("DELETE", m.baseUrl+"/token/"+keyID, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
 	}
 
-	return &token, nil
+	resp, err := m.cl.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("failed to revoke token, status code: %d", resp.StatusCode)
+	}
+
+	return nil
 }

--- a/pkg/repo/user.go
+++ b/pkg/repo/user.go
@@ -82,3 +82,15 @@ func (u *User) GetAPIKeys(ctx context.Context, userID string) ([]string, error) 
 
 	return keys, nil
 }
+
+// RevokeToken removes the specified API key for a user from the Redis store. Returns an error if the operation fails.
+func (u *User) RevokeToken(ctx context.Context, userID string, apiKeyID string) error {
+	redisKey := u.keyPrefix + userID
+
+	_, err := u.db.ZRem(ctx, redisKey, apiKeyID).Result()
+	if err != nil {
+		return fmt.Errorf("failed to revoke API key: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Summary

This pull request introduces API token revocation functionality to the Telegram bot and its associated services. It includes:

- **Unit Tests**: Comprehensive tests for Telegram bot handlers and message parsing.
- **Token Revocation**: Addition of `RevokeToken` method in `TokenService` and `/revoke_token` command handling in the bot.
- **Refactoring**: Refactored token expiration handling by switching `ExpiresIn` to `time.Duration` for better clarity.

### Changes

- Added unit tests for bot commands to ensure reliability and error handling.
- Implemented API token revocation with support in the service, repository, and bot.
- Adjusted test cases to accommodate refactored expiration handling and new revocation feature.
