### PR TITLE
Standardize Redis key prefix for user API keys

### DIFF
--- a/pkg/bot/handlers.go
+++ b/pkg/bot/handlers.go
@@ -12,8 +12,20 @@ import (
 )
 
 const (
-	welcomeMessage        = "👋 Welcome to Make It Public Bot!\n\nI help you manage API tokens for https://make-it-public.dev - a service that allows you to securely publish services hidden behind NAT.\n\nUse /help to see available commands."
-	helpMessage           = "Available Commands:\n\n/start - Show welcome message\n/help - Display this help message\n/new_token - Generate a new API token\n\nAbout Make It Public:\nMake It Public allows you to securely expose services that are behind NAT or firewalls to the internet."
+	welcomeMessage = `👋 Welcome to Make It Public Bot!
+
+I help you manage API tokens for https://make-it-public.dev - a service that allows you to securely publish services hidden behind NAT.
+
+Use /help to see available commands.`
+	helpMessage = `Available Commands:
+
+/start - Show welcome message
+/help - Display this help message
+/new_token - Generate a new API token
+/revoke_token - Revoke your current API token
+
+About Make It Public:
+Make It Public allows you to securely expose services that are behind NAT or firewalls to the internet.`
 	unknownCommandMessage = "❓ Unknown command.\n\nUse /help to see the list of available commands."
 	tokenCreatedMessage   = "🔑 Your New API Token\n\n%s\n\n⏱ Valid until: %s\n\nKeep this token secure and don't share it with others."
 	tokenExistsMessage    = "⚠️ You already have an active API token. You can create a new one after your current token expires."

--- a/pkg/repo/user.go
+++ b/pkg/repo/user.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	ttlOffset = 60 * time.Second
+	ttlOffset    = 60 * time.Second
+	apiKeyPrefix = "USER_KEYS::"
 )
 
 type Config struct {
@@ -43,7 +44,7 @@ func (u *User) Close() error {
 
 // AddAPIKey adds an API key with an expiration time to the user's Redis store. Returns an error if the operation fails.
 func (u *User) AddAPIKey(ctx context.Context, userID string, apiKeyID string, expiresIn time.Duration) error {
-	redisKey := u.keyPrefix + userID
+	redisKey := u.keyPrefix + apiKeyPrefix + userID
 
 	_, err := u.db.ZAdd(ctx, redisKey, redis.Z{
 		Score:  float64(time.Now().Add(expiresIn - ttlOffset).Unix()),
@@ -62,7 +63,7 @@ func (u *User) AddAPIKey(ctx context.Context, userID string, apiKeyID string, ex
 
 // GetAPIKeys retrieves all API keys for a user from the Redis store. Returns a slice of API keys and an error if the operation fails.
 func (u *User) GetAPIKeys(ctx context.Context, userID string) ([]string, error) {
-	redisKey := u.keyPrefix + userID
+	redisKey := u.keyPrefix + apiKeyPrefix + userID
 
 	// clean up expired keys
 	now := time.Now().Unix()
@@ -85,7 +86,7 @@ func (u *User) GetAPIKeys(ctx context.Context, userID string) ([]string, error) 
 
 // RevokeToken removes the specified API key for a user from the Redis store. Returns an error if the operation fails.
 func (u *User) RevokeToken(ctx context.Context, userID string, apiKeyID string) error {
-	redisKey := u.keyPrefix + userID
+	redisKey := u.keyPrefix + apiKeyPrefix + userID
 
 	_, err := u.db.ZRem(ctx, redisKey, apiKeyID).Result()
 	if err != nil {

--- a/pkg/repo/user_test.go
+++ b/pkg/repo/user_test.go
@@ -105,7 +105,7 @@ func TestGetAPIKeys(t *testing.T) {
 	mr.FastForward(expiresIn + ttlOffset + time.Second)
 
 	// Manually delete the keys to simulate expiration
-	redisKey := user.keyPrefix + userID
+	redisKey := user.keyPrefix + apiKeyPrefix + userID
 	user.db.Del(ctx, redisKey)
 
 	// Keys should be empty after deletion


### PR DESCRIPTION
Ensures consistent naming for user API keys in Redis by introducing a namespace prefix. Updates methods and tests to comply with the new key naming convention and improves documentation for related commands and help messages.