### PR TITLE
Handle missing tokens in revoke_token command

### DIFF
--- a/pkg/bot/handlers_test.go
+++ b/pkg/bot/handlers_test.go
@@ -109,6 +109,17 @@ func TestHandleCommand(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:    "revoke_token command - no token to revoke",
+			command: "revoke_token",
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				mockTokenSvc.EXPECT().RevokeToken(mock.Anything, "456").Return(core.ErrTokenNotFound)
+			},
+			chatID:   123,
+			userID:   456,
+			wantText: noTokenToRevokeMessage,
+			wantErr:  false,
+		},
+		{
 			name:    "revoke_token command - error",
 			command: "revoke_token",
 			setupMocks: func(mockTokenSvc *MockTokenService) {

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	ErrMaxTokensExceeded = fmt.Errorf("maximum tokens exceeded")
+	ErrTokenNotFound     = fmt.Errorf("token not found")
 )
 
 type UserRepo interface {
@@ -67,7 +68,7 @@ func (s *Service) RevokeToken(ctx context.Context, userID string) error {
 	}
 
 	if len(keys) == 0 {
-		return fmt.Errorf("no API keys found for user %s", userID)
+		return ErrTokenNotFound
 	}
 
 	if len(keys) > 1 {

--- a/pkg/core/svc_test.go
+++ b/pkg/core/svc_test.go
@@ -166,7 +166,7 @@ func TestRevokeToken(t *testing.T) {
 			userID:       "user123",
 			existingKeys: []string{},
 			getKeysErr:   nil,
-			expectedErr:  "no API keys found for user user123",
+			expectedErr:  ErrTokenNotFound.Error(),
 		},
 		{
 			name:         "multiple API keys found",


### PR DESCRIPTION
### Summary

This pull request resolves an issue where the `revoke_token` command fails or provides unclear feedback when no tokens exist. A new error type `ErrTokenNotFound` has been introduced to standardize error handling in such cases.

### Changes

- Added `ErrTokenNotFound` to improve clarity when no tokens are found.
- Updated the `revoke_token` command to display a user-friendly message in these situations.
- Adjusted and enhanced tests to accommodate the new behavior.
