### PR TITLE
Optimize QEMU setup and platform selection in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
+        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
       - name: Set up Docker Buildx
@@ -58,7 +59,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{  github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
       - if: github.ref_type == 'tag'
         name: Deploy to DigitalOcean Droplet
         uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f


### PR DESCRIPTION
**Description**
This pull request enhances the CI workflow by introducing conditional logic to:
- Skip QEMU setup when unnecessary.
- Limit build platforms based on the event type.

These changes streamline the CI process and ensure optimal configurations are applied.