### PR TITLE
Ask token lifetime

### DIFF
--- a/pkg/core/create_token.go
+++ b/pkg/core/create_token.go
@@ -9,11 +9,13 @@ import (
 )
 
 const (
+	secondsInDay        = 24 * 60 * 60
 	tokenCreatedMessage = "🔑 Your New API Token\n\n%s\n\n⏱ Valid until: %s\n\nKeep this token secure and don't share it with others."
 )
 
 const (
 	StateTokenExists conv.State = "tokenExists"
+	StateNewToken    conv.State = "newToken"
 )
 
 // CreateToken generates a new API token for the specified user, storing it in the repository, if token limits are not exceeded.
@@ -24,12 +26,12 @@ func (s *Service) CreateToken(ctx context.Context, userID string) (*Response, er
 		return nil, fmt.Errorf("failed to get API keys: %w", err)
 	}
 
-	if len(keys) > 0 {
-		c, err := s.repo.GetConversation(ctx, userID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get conversation: %w", err)
-		}
+	c, err := s.repo.GetConversation(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get conversation: %w", err)
+	}
 
+	if len(keys) > 0 {
 		questions := conv.NewQuestions(
 			[]conv.Question{{
 				Text:    "You already have an active API token. Do you want to regenerate it?",
@@ -53,18 +55,25 @@ func (s *Service) CreateToken(ctx context.Context, userID string) (*Response, er
 		}, nil
 	}
 
-	token, err := s.prov.GenerateToken()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate token: %w", err)
+	questions := conv.NewQuestions(
+		[]conv.Question{{
+			Text:    "What is the expiration period for your new API token?",
+			Answers: []string{"1 day", "7 days", "30 days", "90 days"},
+		}},
+	)
+
+	if err := c.Start(StateNewToken, questions); err != nil {
+		return nil, fmt.Errorf("failed to start questions: %w", err)
 	}
 
-	if err = s.repo.AddAPIKey(ctx, userID, token.KeyID, token.ExpiresIn); err != nil {
-		return nil, fmt.Errorf("failed to add API key: %w", err)
+	q, _ := c.Current()
+	if err := s.repo.SaveConversation(ctx, c); err != nil {
+		return nil, fmt.Errorf("failed to save conversation: %w", err)
 	}
 
-	expiresAt := time.Now().Add(token.ExpiresIn).Format(time.DateTime)
 	return &Response{
-		Message: fmt.Sprintf(tokenCreatedMessage, token.Token, expiresAt),
+		Message: q.Text,
+		Answers: q.Answers,
 	}, nil
 }
 
@@ -85,4 +94,40 @@ func (s *Service) handleTokenExistsResult(ctx context.Context, userID string, an
 	}
 
 	return s.CreateToken(ctx, userID)
+}
+
+func (s *Service) handleNewTokenResult(ctx context.Context, userID string, answers []conv.QuestionAnswer) (*Response, error) {
+	if len(answers) != 1 {
+		return nil, fmt.Errorf("expected exactly one answer for newToken question, got %d", len(answers))
+	}
+
+	var expiresIn int64
+	switch answers[0].Answer {
+	case "1 day":
+		expiresIn = secondsInDay
+	case "7 days":
+		expiresIn = 7 * secondsInDay
+	case "30 days":
+		expiresIn = 30 * secondsInDay
+	case "90 days":
+		expiresIn = 90 * secondsInDay
+	default:
+		return &Response{
+			Message: "Invalid expiration period selected. Please select one of the available options.",
+		}, nil
+	}
+
+	token, err := s.prov.GenerateToken(expiresIn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate token: %w", err)
+	}
+
+	if err = s.repo.AddAPIKey(ctx, userID, token.KeyID, token.ExpiresIn); err != nil {
+		return nil, fmt.Errorf("failed to add API key: %w", err)
+	}
+
+	expiresAt := time.Now().Add(token.ExpiresIn).Format(time.DateTime)
+	return &Response{
+		Message: fmt.Sprintf(tokenCreatedMessage, token.Token, expiresAt),
+	}, nil
 }

--- a/pkg/core/mit_prov_mock.go
+++ b/pkg/core/mit_prov_mock.go
@@ -19,9 +19,9 @@ func (_m *MockMITProv) EXPECT() *MockMITProv_Expecter {
 	return &MockMITProv_Expecter{mock: &_m.Mock}
 }
 
-// GenerateToken provides a mock function with no fields
-func (_m *MockMITProv) GenerateToken() (*APIToken, error) {
-	ret := _m.Called()
+// GenerateToken provides a mock function with given fields: ttl
+func (_m *MockMITProv) GenerateToken(ttl int64) (*APIToken, error) {
+	ret := _m.Called(ttl)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GenerateToken")
@@ -29,19 +29,19 @@ func (_m *MockMITProv) GenerateToken() (*APIToken, error) {
 
 	var r0 *APIToken
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*APIToken, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(int64) (*APIToken, error)); ok {
+		return rf(ttl)
 	}
-	if rf, ok := ret.Get(0).(func() *APIToken); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(int64) *APIToken); ok {
+		r0 = rf(ttl)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*APIToken)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(int64) error); ok {
+		r1 = rf(ttl)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -55,13 +55,14 @@ type MockMITProv_GenerateToken_Call struct {
 }
 
 // GenerateToken is a helper method to define mock.On call
-func (_e *MockMITProv_Expecter) GenerateToken() *MockMITProv_GenerateToken_Call {
-	return &MockMITProv_GenerateToken_Call{Call: _e.mock.On("GenerateToken")}
+//   - ttl int64
+func (_e *MockMITProv_Expecter) GenerateToken(ttl interface{}) *MockMITProv_GenerateToken_Call {
+	return &MockMITProv_GenerateToken_Call{Call: _e.mock.On("GenerateToken", ttl)}
 }
 
-func (_c *MockMITProv_GenerateToken_Call) Run(run func()) *MockMITProv_GenerateToken_Call {
+func (_c *MockMITProv_GenerateToken_Call) Run(run func(ttl int64)) *MockMITProv_GenerateToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(int64))
 	})
 	return _c
 }
@@ -71,7 +72,7 @@ func (_c *MockMITProv_GenerateToken_Call) Return(_a0 *APIToken, _a1 error) *Mock
 	return _c
 }
 
-func (_c *MockMITProv_GenerateToken_Call) RunAndReturn(run func() (*APIToken, error)) *MockMITProv_GenerateToken_Call {
+func (_c *MockMITProv_GenerateToken_Call) RunAndReturn(run func(int64) (*APIToken, error)) *MockMITProv_GenerateToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -85,6 +85,8 @@ func (s *Service) HandleMessage(ctx context.Context, userID string, message stri
 	switch state {
 	case StateTokenExists:
 		return s.handleTokenExistsResult(ctx, userID, res)
+	case StateNewToken:
+		return s.handleNewTokenResult(ctx, userID, res)
 	default:
 		return nil, fmt.Errorf("unsupported conversation state: %s", state)
 	}

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -23,7 +23,7 @@ type UserRepo interface {
 }
 
 type MITProv interface {
-	GenerateToken() (*APIToken, error)
+	GenerateToken(ttl int64) (*APIToken, error)
 	RevokeToken(keyID string) error
 }
 

--- a/pkg/prov/mit.go
+++ b/pkg/prov/mit.go
@@ -44,9 +44,13 @@ type generateTokenResponse struct {
 }
 
 // GenerateToken sends a request to generate an API token and returns the token along with its metadata or an error.
-func (m *MIT) GenerateToken() (*core.APIToken, error) {
+func (m *MIT) GenerateToken(ttl int64) (*core.APIToken, error) {
+	if ttl <= 0 {
+		ttl = m.defaultTTL
+	}
+
 	req := generateTokenRequest{
-		TTL: m.defaultTTL,
+		TTL: ttl,
 	}
 
 	jsonReq, err := json.Marshal(req)

--- a/pkg/prov/mit_test.go
+++ b/pkg/prov/mit_test.go
@@ -100,7 +100,7 @@ func TestGenerateToken(t *testing.T) {
 			}
 
 			// Call the method
-			token, err := mit.GenerateToken()
+			token, err := mit.GenerateToken(tt.defaultTTL)
 
 			// Verify results
 			if tt.expectedError != "" {


### PR DESCRIPTION
This pull request introduces a new feature to allow users to specify an expiration period for API tokens and refactors the related codebase to support this functionality. Key changes include adding a new conversation state for token expiration selection, modifying the token generation process to accept a custom TTL (time-to-live), and updating tests and mocks to reflect the new behavior.

### Feature Enhancements:
* Added a new conversation state `StateNewToken` to handle user input for selecting the expiration period of API tokens. (`pkg/core/create_token.go`, [pkg/core/create_token.goR12-R18](diffhunk://#diff-0757a8019272df792f29757cc2e6ec96e462151d829b08ecf214db9001f68b4eR12-R18))
* Updated the `GenerateToken` method to accept a `ttl` parameter, allowing tokens to have a customizable expiration period. (`pkg/core/svc.go`, [[1]](diffhunk://#diff-3417b78b4c53da291253217e83c20a5aa880d70b184e632ce61fda2a7289c90aL26-R26); `pkg/prov/mit.go`, [[2]](diffhunk://#diff-4e0734316dddd103147065201217b3940417edba9f384768b1989b9a1d11f0d7L47-R53)

### Refactoring:
* Refactored the `CreateToken` method to prompt users with expiration options and save the conversation state. (`pkg/core/create_token.go`, [[1]](diffhunk://#diff-0757a8019272df792f29757cc2e6ec96e462151d829b08ecf214db9001f68b4eL27-R34) [[2]](diffhunk://#diff-0757a8019272df792f29757cc2e6ec96e462151d829b08ecf214db9001f68b4eL56-R76)
* Added a new method `handleNewTokenResult` to process user responses and generate tokens with the selected expiration period. (`pkg/core/create_token.go`, [pkg/core/create_token.goR98-R133](diffhunk://#diff-0757a8019272df792f29757cc2e6ec96e462151d829b08ecf214db9001f68b4eR98-R133))

### Testing Updates:
* Updated unit tests to validate the new expiration period selection functionality and ensure proper handling of different scenarios. (`pkg/core/create_token_test.go`, [[1]](diffhunk://#diff-a4cdf4d8bb89ed5ce2f9b4dcbdca638a27b841e972159dacc15e128644ec18daL44-R43) [[2]](diffhunk://#diff-a4cdf4d8bb89ed5ce2f9b4dcbdca638a27b841e972159dacc15e128644ec18daL86-R86) [[3]](diffhunk://#diff-a4cdf4d8bb89ed5ce2f9b4dcbdca638a27b841e972159dacc15e128644ec18daL104-R104) [[4]](diffhunk://#diff-a4cdf4d8bb89ed5ce2f9b4dcbdca638a27b841e972159dacc15e128644ec18daL217-R221)
* Modified mocks for `GenerateToken` to include the new `ttl` parameter. (`pkg/core/mit_prov_mock.go`, [[1]](diffhunk://#diff-d2964747443ea7ba96287d2400c7931c025ab2d4b2e4aa39b4c431a220e76af6L22-R44) [[2]](diffhunk://#diff-d2964747443ea7ba96287d2400c7931c025ab2d4b2e4aa39b4c431a220e76af6L58-R65)

### Additional Changes:
* Updated the `HandleMessage` method to support the new `StateNewToken` state. (`pkg/core/svc.go`, [pkg/core/svc.goR88-R89](diffhunk://#diff-3417b78b4c53da291253217e83c20a5aa880d70b184e632ce61fda2a7289c90aR88-R89))
* Adjusted the default TTL logic in the `GenerateToken` implementation to fall back to a predefined value if no valid TTL is provided. (`pkg/prov/mit.go`, [pkg/prov/mit.goL47-R53](diffhunk://#diff-4e0734316dddd103147065201217b3940417edba9f384768b1989b9a1d11f0d7L47-R53))