### PR TITLE
Update GenerateToken function to accept keyID parameter for token generation

### DIFF
--- a/pkg/core/create_token.go
+++ b/pkg/core/create_token.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -20,6 +21,10 @@ const (
 	StateNewToken        conv.State = "newToken"
 )
 
+var (
+	ErrInvalidExpirationPeriod = fmt.Errorf("invalid expiration period selected")
+)
+
 // CreateToken generates a new API token for the specified user, storing it in the repository, if token limits are not exceeded.
 // Returns an error if the token limit is reached, fails to generate the token, or fails to save the token in the repository.
 func (s *Service) CreateToken(ctx context.Context, userID string) (*Response, error) {
@@ -28,12 +33,12 @@ func (s *Service) CreateToken(ctx context.Context, userID string) (*Response, er
 		return nil, fmt.Errorf("failed to get API keys: %w", err)
 	}
 
-	c, err := s.repo.GetConversation(ctx, userID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get conversation: %w", err)
-	}
-
 	if len(keys) >= maxTokensPerUser {
+		c, err := s.repo.GetConversation(ctx, userID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get conversation: %w", err)
+		}
+
 		questions := conv.NewQuestions(
 			[]conv.Question{{
 				Text:    "You already have an active API token. Do you want to regenerate it?",
@@ -57,26 +62,7 @@ func (s *Service) CreateToken(ctx context.Context, userID string) (*Response, er
 		}, nil
 	}
 
-	questions := conv.NewQuestions(
-		[]conv.Question{{
-			Text:    "What is the expiration period for your new API token?",
-			Answers: []string{"1 day", "7 days", "30 days", "90 days"},
-		}},
-	)
-
-	if err := c.Start(StateNewToken, questions); err != nil {
-		return nil, fmt.Errorf("failed to start questions: %w", err)
-	}
-
-	q, _ := c.Current()
-	if err := s.repo.SaveConversation(ctx, c); err != nil {
-		return nil, fmt.Errorf("failed to save conversation: %w", err)
-	}
-
-	return &Response{
-		Message: q.Text,
-		Answers: q.Answers,
-	}, nil
+	return s.askForTokenExpiration(ctx, userID, StateNewToken)
 }
 
 // handleTokenExistsResult processes the result of a "token exists" question and takes appropriate action based on the answer.
@@ -91,52 +77,19 @@ func (s *Service) handleTokenExistsResult(ctx context.Context, userID string, an
 		}, nil
 	}
 
-	c, err := s.repo.GetConversation(ctx, userID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get conversation: %w", err)
-	}
-
-	questions := conv.NewQuestions(
-		[]conv.Question{{
-			Text:    "What is the expiration period for your new API token?",
-			Answers: []string{"1 day", "7 days", "30 days", "90 days"},
-		}},
-	)
-
-	if err := c.Start(StateTokenRegenerate, questions); err != nil {
-		return nil, fmt.Errorf("failed to start questions: %w", err)
-	}
-
-	q, _ := c.Current()
-	if err := s.repo.SaveConversation(ctx, c); err != nil {
-		return nil, fmt.Errorf("failed to save conversation: %w", err)
-	}
-
-	return &Response{
-		Message: q.Text,
-		Answers: q.Answers,
-	}, nil
+	return s.askForTokenExpiration(ctx, userID, StateTokenRegenerate)
 }
 
 func (s *Service) handleNewTokenResult(ctx context.Context, userID string, answers []conv.QuestionAnswer) (*Response, error) {
-	if len(answers) != 1 {
-		return nil, fmt.Errorf("expected exactly one answer for newToken question, got %d", len(answers))
-	}
+	expiresIn, err := s.parseExpirationAnswer(answers)
 
-	var expiresIn int64
-	switch answers[0].Answer {
-	case "1 day":
-		expiresIn = secondsInDay
-	case "7 days":
-		expiresIn = 7 * secondsInDay
-	case "30 days":
-		expiresIn = 30 * secondsInDay
-	case "90 days":
-		expiresIn = 90 * secondsInDay
-	default:
+	switch {
+	case errors.Is(err, ErrInvalidExpirationPeriod):
 		return &Response{
 			Message: "Invalid expiration period selected. Please select one of the available options.",
 		}, nil
+	case err != nil:
+		return nil, fmt.Errorf("failed to parse expiration answer: %w", err)
 	}
 
 	token, err := s.prov.GenerateToken("", expiresIn)
@@ -155,24 +108,15 @@ func (s *Service) handleNewTokenResult(ctx context.Context, userID string, answe
 }
 
 func (s *Service) handleTokenRegenerateResult(ctx context.Context, userID string, answers []conv.QuestionAnswer) (*Response, error) {
-	if len(answers) != 1 {
-		return nil, fmt.Errorf("expected exactly one answer for newToken question, got %d", len(answers))
-	}
+	expiresIn, err := s.parseExpirationAnswer(answers)
 
-	var expiresIn int64
-	switch answers[0].Answer {
-	case "1 day":
-		expiresIn = secondsInDay
-	case "7 days":
-		expiresIn = 7 * secondsInDay
-	case "30 days":
-		expiresIn = 30 * secondsInDay
-	case "90 days":
-		expiresIn = 90 * secondsInDay
-	default:
+	switch {
+	case errors.Is(err, ErrInvalidExpirationPeriod):
 		return &Response{
 			Message: "Invalid expiration period selected. Please select one of the available options.",
 		}, nil
+	case err != nil:
+		return nil, fmt.Errorf("failed to parse expiration answer: %w", err)
 	}
 
 	keys, err := s.repo.GetAPIKeys(ctx, userID)
@@ -206,4 +150,54 @@ func (s *Service) handleTokenRegenerateResult(ctx context.Context, userID string
 	return &Response{
 		Message: fmt.Sprintf(tokenCreatedMessage, token.Token, expiresAt),
 	}, nil
+}
+
+func (s *Service) askForTokenExpiration(ctx context.Context, userID string, state conv.State) (*Response, error) {
+	c, err := s.repo.GetConversation(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get conversation: %w", err)
+	}
+
+	questions := conv.NewQuestions(
+		[]conv.Question{{
+			Text:    "What is the expiration period for your new API token?",
+			Answers: []string{"1 day", "7 days", "30 days", "90 days"},
+		}},
+	)
+
+	if err := c.Start(state, questions); err != nil {
+		return nil, fmt.Errorf("failed to start questions: %w", err)
+	}
+
+	q, _ := c.Current()
+	if err := s.repo.SaveConversation(ctx, c); err != nil {
+		return nil, fmt.Errorf("failed to save conversation: %w", err)
+	}
+
+	return &Response{
+		Message: q.Text,
+		Answers: q.Answers,
+	}, nil
+}
+
+func (s *Service) parseExpirationAnswer(answers []conv.QuestionAnswer) (int64, error) {
+	if len(answers) != 1 {
+		return 0, fmt.Errorf("expected exactly one answer for expiration question, got %d", len(answers))
+	}
+
+	var expiresIn int64
+	switch answers[0].Answer {
+	case "1 day":
+		expiresIn = secondsInDay
+	case "7 days":
+		expiresIn = 7 * secondsInDay
+	case "30 days":
+		expiresIn = 30 * secondsInDay
+	case "90 days":
+		expiresIn = 90 * secondsInDay
+	default:
+		return 0, ErrInvalidExpirationPeriod
+	}
+
+	return expiresIn, nil
 }

--- a/pkg/core/create_token.go
+++ b/pkg/core/create_token.go
@@ -9,13 +9,15 @@ import (
 )
 
 const (
+	maxTokensPerUser    = 1
 	secondsInDay        = 24 * 60 * 60
 	tokenCreatedMessage = "🔑 Your New API Token\n\n%s\n\n⏱ Valid until: %s\n\nKeep this token secure and don't share it with others."
 )
 
 const (
-	StateTokenExists conv.State = "tokenExists"
-	StateNewToken    conv.State = "newToken"
+	StateTokenRegenerate conv.State = "tokenRegenerate"
+	StateTokenExists     conv.State = "tokenExists"
+	StateNewToken        conv.State = "newToken"
 )
 
 // CreateToken generates a new API token for the specified user, storing it in the repository, if token limits are not exceeded.
@@ -31,7 +33,7 @@ func (s *Service) CreateToken(ctx context.Context, userID string) (*Response, er
 		return nil, fmt.Errorf("failed to get conversation: %w", err)
 	}
 
-	if len(keys) > 0 {
+	if len(keys) >= maxTokensPerUser {
 		questions := conv.NewQuestions(
 			[]conv.Question{{
 				Text:    "You already have an active API token. Do you want to regenerate it?",
@@ -89,11 +91,31 @@ func (s *Service) handleTokenExistsResult(ctx context.Context, userID string, an
 		}, nil
 	}
 
-	if err := s.RevokeToken(ctx, userID); err != nil {
-		return nil, fmt.Errorf("failed to revoke existing token: %w", err)
+	c, err := s.repo.GetConversation(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get conversation: %w", err)
 	}
 
-	return s.CreateToken(ctx, userID)
+	questions := conv.NewQuestions(
+		[]conv.Question{{
+			Text:    "What is the expiration period for your new API token?",
+			Answers: []string{"1 day", "7 days", "30 days", "90 days"},
+		}},
+	)
+
+	if err := c.Start(StateTokenRegenerate, questions); err != nil {
+		return nil, fmt.Errorf("failed to start questions: %w", err)
+	}
+
+	q, _ := c.Current()
+	if err := s.repo.SaveConversation(ctx, c); err != nil {
+		return nil, fmt.Errorf("failed to save conversation: %w", err)
+	}
+
+	return &Response{
+		Message: q.Text,
+		Answers: q.Answers,
+	}, nil
 }
 
 func (s *Service) handleNewTokenResult(ctx context.Context, userID string, answers []conv.QuestionAnswer) (*Response, error) {
@@ -118,6 +140,60 @@ func (s *Service) handleNewTokenResult(ctx context.Context, userID string, answe
 	}
 
 	token, err := s.prov.GenerateToken("", expiresIn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate token: %w", err)
+	}
+
+	if err = s.repo.AddAPIKey(ctx, userID, token.KeyID, token.ExpiresIn); err != nil {
+		return nil, fmt.Errorf("failed to add API key: %w", err)
+	}
+
+	expiresAt := time.Now().Add(token.ExpiresIn).Format(time.DateTime)
+	return &Response{
+		Message: fmt.Sprintf(tokenCreatedMessage, token.Token, expiresAt),
+	}, nil
+}
+
+func (s *Service) handleTokenRegenerateResult(ctx context.Context, userID string, answers []conv.QuestionAnswer) (*Response, error) {
+	if len(answers) != 1 {
+		return nil, fmt.Errorf("expected exactly one answer for newToken question, got %d", len(answers))
+	}
+
+	var expiresIn int64
+	switch answers[0].Answer {
+	case "1 day":
+		expiresIn = secondsInDay
+	case "7 days":
+		expiresIn = 7 * secondsInDay
+	case "30 days":
+		expiresIn = 30 * secondsInDay
+	case "90 days":
+		expiresIn = 90 * secondsInDay
+	default:
+		return &Response{
+			Message: "Invalid expiration period selected. Please select one of the available options.",
+		}, nil
+	}
+
+	keys, err := s.repo.GetAPIKeys(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get API keys: %w", err)
+	}
+
+	if len(keys) != 1 {
+		return nil, fmt.Errorf("expected exactly one API key for user %s, got %d", userID, len(keys))
+	}
+
+	keyID := keys[0]
+	if err := s.prov.RevokeToken(keyID); err != nil {
+		return nil, fmt.Errorf("failed to revoke existing token: %w", err)
+	}
+
+	if err := s.repo.RevokeToken(ctx, userID, keyID); err != nil {
+		return nil, fmt.Errorf("failed to remove API key from repository: %w", err)
+	}
+
+	token, err := s.prov.GenerateToken(keyID, expiresIn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate token: %w", err)
 	}

--- a/pkg/core/create_token.go
+++ b/pkg/core/create_token.go
@@ -117,7 +117,7 @@ func (s *Service) handleNewTokenResult(ctx context.Context, userID string, answe
 		}, nil
 	}
 
-	token, err := s.prov.GenerateToken(expiresIn)
+	token, err := s.prov.GenerateToken("", expiresIn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate token: %w", err)
 	}

--- a/pkg/core/mit_prov_mock.go
+++ b/pkg/core/mit_prov_mock.go
@@ -19,9 +19,9 @@ func (_m *MockMITProv) EXPECT() *MockMITProv_Expecter {
 	return &MockMITProv_Expecter{mock: &_m.Mock}
 }
 
-// GenerateToken provides a mock function with given fields: ttl
-func (_m *MockMITProv) GenerateToken(ttl int64) (*APIToken, error) {
-	ret := _m.Called(ttl)
+// GenerateToken provides a mock function with given fields: keyID, ttl
+func (_m *MockMITProv) GenerateToken(keyID string, ttl int64) (*APIToken, error) {
+	ret := _m.Called(keyID, ttl)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GenerateToken")
@@ -29,19 +29,19 @@ func (_m *MockMITProv) GenerateToken(ttl int64) (*APIToken, error) {
 
 	var r0 *APIToken
 	var r1 error
-	if rf, ok := ret.Get(0).(func(int64) (*APIToken, error)); ok {
-		return rf(ttl)
+	if rf, ok := ret.Get(0).(func(string, int64) (*APIToken, error)); ok {
+		return rf(keyID, ttl)
 	}
-	if rf, ok := ret.Get(0).(func(int64) *APIToken); ok {
-		r0 = rf(ttl)
+	if rf, ok := ret.Get(0).(func(string, int64) *APIToken); ok {
+		r0 = rf(keyID, ttl)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*APIToken)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(int64) error); ok {
-		r1 = rf(ttl)
+	if rf, ok := ret.Get(1).(func(string, int64) error); ok {
+		r1 = rf(keyID, ttl)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -55,14 +55,15 @@ type MockMITProv_GenerateToken_Call struct {
 }
 
 // GenerateToken is a helper method to define mock.On call
+//   - keyID string
 //   - ttl int64
-func (_e *MockMITProv_Expecter) GenerateToken(ttl interface{}) *MockMITProv_GenerateToken_Call {
-	return &MockMITProv_GenerateToken_Call{Call: _e.mock.On("GenerateToken", ttl)}
+func (_e *MockMITProv_Expecter) GenerateToken(keyID interface{}, ttl interface{}) *MockMITProv_GenerateToken_Call {
+	return &MockMITProv_GenerateToken_Call{Call: _e.mock.On("GenerateToken", keyID, ttl)}
 }
 
-func (_c *MockMITProv_GenerateToken_Call) Run(run func(ttl int64)) *MockMITProv_GenerateToken_Call {
+func (_c *MockMITProv_GenerateToken_Call) Run(run func(keyID string, ttl int64)) *MockMITProv_GenerateToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(int64))
+		run(args[0].(string), args[1].(int64))
 	})
 	return _c
 }
@@ -72,7 +73,7 @@ func (_c *MockMITProv_GenerateToken_Call) Return(_a0 *APIToken, _a1 error) *Mock
 	return _c
 }
 
-func (_c *MockMITProv_GenerateToken_Call) RunAndReturn(run func(int64) (*APIToken, error)) *MockMITProv_GenerateToken_Call {
+func (_c *MockMITProv_GenerateToken_Call) RunAndReturn(run func(string, int64) (*APIToken, error)) *MockMITProv_GenerateToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -23,7 +23,7 @@ type UserRepo interface {
 }
 
 type MITProv interface {
-	GenerateToken(ttl int64) (*APIToken, error)
+	GenerateToken(keyID string, ttl int64) (*APIToken, error)
 	RevokeToken(keyID string) error
 }
 

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -87,6 +87,8 @@ func (s *Service) HandleMessage(ctx context.Context, userID string, message stri
 		return s.handleTokenExistsResult(ctx, userID, res)
 	case StateNewToken:
 		return s.handleNewTokenResult(ctx, userID, res)
+	case StateTokenRegenerate:
+		return s.handleTokenRegenerateResult(ctx, userID, res)
 	default:
 		return nil, fmt.Errorf("unsupported conversation state: %s", state)
 	}

--- a/pkg/prov/mit.go
+++ b/pkg/prov/mit.go
@@ -44,13 +44,14 @@ type generateTokenResponse struct {
 }
 
 // GenerateToken sends a request to generate an API token and returns the token along with its metadata or an error.
-func (m *MIT) GenerateToken(ttl int64) (*core.APIToken, error) {
+func (m *MIT) GenerateToken(keyID string, ttl int64) (*core.APIToken, error) {
 	if ttl <= 0 {
 		ttl = m.defaultTTL
 	}
 
 	req := generateTokenRequest{
-		TTL: ttl,
+		KeyID: keyID,
+		TTL:   ttl,
 	}
 
 	jsonReq, err := json.Marshal(req)

--- a/pkg/prov/mit_test.go
+++ b/pkg/prov/mit_test.go
@@ -100,7 +100,7 @@ func TestGenerateToken(t *testing.T) {
 			}
 
 			// Call the method
-			token, err := mit.GenerateToken(tt.defaultTTL)
+			token, err := mit.GenerateToken("", tt.defaultTTL)
 
 			// Verify results
 			if tt.expectedError != "" {


### PR DESCRIPTION
This pull request introduces significant changes to the token generation and regeneration logic in the `pkg/core` package, improving modularity, error handling, and test coverage. Key updates include the introduction of a `maxTokensPerUser` limit, refactoring of token expiration logic into reusable methods, and updates to the `GenerateToken` interface to support token regeneration with a specified `keyID`.

### Core functionality improvements:

* Introduced a `maxTokensPerUser` constant to enforce a limit of one active token per user. Added logic to check this limit before creating a new token. (`pkg/core/create_token.go`, [[1]](diffhunk://#diff-0757a8019272df792f29757cc2e6ec96e462151d829b08ecf214db9001f68b4eR5-R27) [[2]](diffhunk://#diff-0757a8019272df792f29757cc2e6ec96e462151d829b08ecf214db9001f68b4eR36-L34)
* Refactored token expiration logic into two new methods, `askForTokenExpiration` and `parseExpirationAnswer`, to improve code reuse and maintainability. (`pkg/core/create_token.go`, [[1]](diffhunk://#diff-0757a8019272df792f29757cc2e6ec96e462151d829b08ecf214db9001f68b4eL58-R65) [[2]](diffhunk://#diff-0757a8019272df792f29757cc2e6ec96e462151d829b08ecf214db9001f68b4eR154-R203)
* Added a new state, `StateTokenRegenerate`, and implemented `handleTokenRegenerateResult` to handle token regeneration, including revoking the old token and generating a new one. (`pkg/core/create_token.go`, [[1]](diffhunk://#diff-0757a8019272df792f29757cc2e6ec96e462151d829b08ecf214db9001f68b4eL92-R140) [[2]](diffhunk://#diff-3417b78b4c53da291253217e83c20a5aa880d70b184e632ce61fda2a7289c90aR90-R91)

### Interface and mock updates:

* Updated the `GenerateToken` method in the `MITProv` interface to accept a `keyID` parameter, allowing token regeneration with a specific key. Adjusted all relevant mock implementations and tests to reflect this change. (`pkg/core/svc.go`, [[1]](diffhunk://#diff-3417b78b4c53da291253217e83c20a5aa880d70b184e632ce61fda2a7289c90aL26-R26); `pkg/core/mit_prov_mock.go`, [[2]](diffhunk://#diff-d2964747443ea7ba96287d2400c7931c025ab2d4b2e4aa39b4c431a220e76af6L22-R44) [[3]](diffhunk://#diff-d2964747443ea7ba96287d2400c7931c025ab2d4b2e4aa39b4c431a220e76af6R58-R66) [[4]](diffhunk://#diff-d2964747443ea7ba96287d2400c7931c025ab2d4b2e4aa39b4c431a220e76af6L75-R76); `pkg/prov/mit.go`, [[5]](diffhunk://#diff-4e0734316dddd103147065201217b3940417edba9f384768b1989b9a1d11f0d7L47-R53)

### Test coverage enhancements:

* Improved test coverage by updating test cases to align with the refactored token generation and regeneration logic. Removed redundant test cases for revoked token errors, as these are now handled in a centralized manner. (`pkg/core/create_token_test.go`, [[1]](diffhunk://#diff-a4cdf4d8bb89ed5ce2f9b4dcbdca638a27b841e972159dacc15e128644ec18daL181) [[2]](diffhunk://#diff-a4cdf4d8bb89ed5ce2f9b4dcbdca638a27b841e972159dacc15e128644ec18daL224-L238) [[3]](diffhunk://#diff-a4cdf4d8bb89ed5ce2f9b4dcbdca638a27b841e972159dacc15e128644ec18daL291-L316)
* Updated tests for the `GenerateToken` method to include the new `keyID` parameter. (`pkg/prov/mit_test.go`, [pkg/prov/mit_test.goL103-R103](diffhunk://#diff-1b7cfc39620658754db87443b23776cbfe0bfd58b9b7617a83d73dfb23c224abL103-R103))