### PR TITLE
Add cancel command to reset conversation and implement ResetConversation method

### DIFF
--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -33,6 +33,7 @@ type TokenService interface {
 	CreateToken(ctx context.Context, userID string) (*core.Response, error)
 	RevokeToken(ctx context.Context, userID string) error
 	HandleMessage(ctx context.Context, userID string, message string) (*core.Response, error)
+	ResetConversation(ctx context.Context, userID string) error
 }
 
 type Service struct {

--- a/pkg/bot/bot_test.go
+++ b/pkg/bot/bot_test.go
@@ -70,10 +70,15 @@ func TestHandle(t *testing.T) {
 				Chat: &tgbotapi.Chat{
 					ID: 123,
 				},
+				From: &tgbotapi.User{
+					ID: 456,
+				},
 			},
-			setupMocks: func() {},
-			wantText:   welcomeMessage,
-			wantErr:    false,
+			setupMocks: func() {
+				mockTokenSvc.EXPECT().ResetConversation(mock.Anything, "456").Return(nil)
+			},
+			wantText: welcomeMessage,
+			wantErr:  false,
 		},
 		{
 			name: "help command",
@@ -88,6 +93,9 @@ func TestHandle(t *testing.T) {
 				},
 				Chat: &tgbotapi.Chat{
 					ID: 123,
+				},
+				From: &tgbotapi.User{
+					ID: 456,
 				},
 			},
 			setupMocks: func() {},
@@ -184,6 +192,9 @@ func TestHandle(t *testing.T) {
 				},
 				Chat: &tgbotapi.Chat{
 					ID: 123,
+				},
+				From: &tgbotapi.User{
+					ID: 456,
 				},
 			},
 			setupMocks: func() {},
@@ -317,6 +328,7 @@ func TestProcessUpdate(t *testing.T) {
 			},
 			setupMocks: func() {
 				mockTg.EXPECT().Send(mock.Anything).Return(tgbotapi.Message{}, nil)
+				mockTokenSvc.EXPECT().ResetConversation(mock.Anything, "456").Return(nil)
 			},
 		},
 	}

--- a/pkg/bot/handlers.go
+++ b/pkg/bot/handlers.go
@@ -23,6 +23,7 @@ Use /help to see available commands.`
 /help - Display this help message
 /new_token - Generate a new API token
 /revoke_token - Revoke your current API token
+/cancel - Cancel the current question
 
 About Make It Public:
 Make It Public allows you to securely expose services that are behind NAT or firewalls to the internet.`
@@ -84,13 +85,19 @@ func (s *Service) Handle(ctx context.Context, msg *tgbotapi.Message) (tgbotapi.M
 
 // handleCommand handles Telegram command messages and generates an appropriate response based on the command received.
 func (s *Service) handleCommand(ctx context.Context, msg *tgbotapi.Message) (tgbotapi.MessageConfig, error) {
+	userID := fmt.Sprintf("%d", msg.From.ID)
+
 	switch msg.Command() {
 	case "start":
+		if err := s.tokenSvc.ResetConversation(ctx, userID); err != nil {
+			slog.ErrorContext(ctx, "Failed to reset conversation on  start", slog.Any("error", err))
+		}
+
 		return newTextMessage(msg.Chat.ID, welcomeMessage), nil
 	case "help":
 		return newTextMessage(msg.Chat.ID, helpMessage), nil
 	case "new_token":
-		resp, err := s.tokenSvc.CreateToken(ctx, fmt.Sprintf("%d", msg.From.ID))
+		resp, err := s.tokenSvc.CreateToken(ctx, userID)
 		switch {
 		case errors.Is(err, core.ErrMaxTokensExceeded):
 			return newTextMessage(msg.Chat.ID, tokenExistsMessage), nil
@@ -100,7 +107,7 @@ func (s *Service) handleCommand(ctx context.Context, msg *tgbotapi.Message) (tgb
 			return newMessage(msg.Chat.ID, resp), nil
 		}
 	case "revoke_token":
-		err := s.tokenSvc.RevokeToken(ctx, fmt.Sprintf("%d", msg.From.ID))
+		err := s.tokenSvc.RevokeToken(ctx, userID)
 
 		switch {
 		case errors.Is(err, core.ErrTokenNotFound):
@@ -110,6 +117,12 @@ func (s *Service) handleCommand(ctx context.Context, msg *tgbotapi.Message) (tgb
 		}
 
 		return newTextMessage(msg.Chat.ID, tokenRevokedMessage), nil
+	case "cancel":
+		if err := s.tokenSvc.ResetConversation(ctx, userID); err != nil {
+			return tgbotapi.MessageConfig{}, fmt.Errorf("failed to reset conversation: %w", err)
+		}
+
+		return newTextMessage(msg.Chat.ID, "Conversation has been reset. You can start over with /new_token."), nil
 	default:
 		return newTextMessage(msg.Chat.ID, unknownCommandMessage), nil
 	}

--- a/pkg/bot/handlers.go
+++ b/pkg/bot/handlers.go
@@ -90,7 +90,7 @@ func (s *Service) handleCommand(ctx context.Context, msg *tgbotapi.Message) (tgb
 	switch msg.Command() {
 	case "start":
 		if err := s.tokenSvc.ResetConversation(ctx, userID); err != nil {
-			slog.ErrorContext(ctx, "Failed to reset conversation on  start", slog.Any("error", err))
+			slog.ErrorContext(ctx, "Failed to reset conversation on start", slog.Any("error", err))
 		}
 
 		return newTextMessage(msg.Chat.ID, welcomeMessage), nil

--- a/pkg/bot/handlers_test.go
+++ b/pkg/bot/handlers_test.go
@@ -44,7 +44,7 @@ func TestHandleCommand(t *testing.T) {
 			name:    "start command",
 			command: "start",
 			setupMocks: func(mockTokenSvc *MockTokenService) {
-				// No mocks needed for start command
+				mockTokenSvc.EXPECT().ResetConversation(mock.Anything, "456").Return(nil)
 			},
 			chatID:   123,
 			userID:   456,
@@ -143,6 +143,17 @@ func TestHandleCommand(t *testing.T) {
 			wantText: unknownCommandMessage,
 			wantErr:  false,
 		},
+		{
+			name:    "cancel command",
+			command: "cancel",
+			setupMocks: func(mockTokenSvc *MockTokenService) {
+				mockTokenSvc.EXPECT().ResetConversation(mock.Anything, "456").Return(nil)
+			},
+			chatID:   123,
+			userID:   456,
+			wantText: "Conversation has been reset. You can start over with /new_token.",
+			wantErr:  false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -228,7 +239,7 @@ func TestHandleMessage(t *testing.T) {
 				},
 			},
 			setupMocks: func(mockTokenSvc *MockTokenService) {
-				// No mocks needed for start command
+				mockTokenSvc.EXPECT().ResetConversation(mock.Anything, "456").Return(nil)
 			},
 			wantText: welcomeMessage,
 			wantErr:  false,

--- a/pkg/bot/token_service_mock.go
+++ b/pkg/bot/token_service_mock.go
@@ -143,6 +143,53 @@ func (_c *MockTokenService_HandleMessage_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// ResetConversation provides a mock function with given fields: ctx, userID
+func (_m *MockTokenService) ResetConversation(ctx context.Context, userID string) error {
+	ret := _m.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResetConversation")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, userID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockTokenService_ResetConversation_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResetConversation'
+type MockTokenService_ResetConversation_Call struct {
+	*mock.Call
+}
+
+// ResetConversation is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *MockTokenService_Expecter) ResetConversation(ctx interface{}, userID interface{}) *MockTokenService_ResetConversation_Call {
+	return &MockTokenService_ResetConversation_Call{Call: _e.mock.On("ResetConversation", ctx, userID)}
+}
+
+func (_c *MockTokenService_ResetConversation_Call) Run(run func(ctx context.Context, userID string)) *MockTokenService_ResetConversation_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockTokenService_ResetConversation_Call) Return(_a0 error) *MockTokenService_ResetConversation_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockTokenService_ResetConversation_Call) RunAndReturn(run func(context.Context, string) error) *MockTokenService_ResetConversation_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RevokeToken provides a mock function with given fields: ctx, userID
 func (_m *MockTokenService) RevokeToken(ctx context.Context, userID string) error {
 	ret := _m.Called(ctx, userID)

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -20,6 +20,7 @@ type UserRepo interface {
 	RevokeToken(ctx context.Context, userID string, apiKeyID string) error
 	SaveConversation(ctx context.Context, conversation *conv.Conversation) error
 	GetConversation(ctx context.Context, conversationID string) (*conv.Conversation, error)
+	DeleteConversation(ctx context.Context, conversationID string) error
 }
 
 type MITProv interface {
@@ -43,6 +44,15 @@ func New(repo UserRepo, prov MITProv) *Service {
 		repo: repo,
 		prov: prov,
 	}
+}
+
+// ResetConversation deletes the conversation associated with a user.
+func (s *Service) ResetConversation(ctx context.Context, userID string) error {
+	if err := s.repo.DeleteConversation(ctx, userID); err != nil {
+		return fmt.Errorf("failed to delete conversation: %w", err)
+	}
+
+	return nil
 }
 
 // HandleMessage processes an incoming user message within a conversation context and returns a response or an error.

--- a/pkg/core/user_repo_mock.go
+++ b/pkg/core/user_repo_mock.go
@@ -75,6 +75,53 @@ func (_c *MockUserRepo_AddAPIKey_Call) RunAndReturn(run func(context.Context, st
 	return _c
 }
 
+// DeleteConversation provides a mock function with given fields: ctx, conversationID
+func (_m *MockUserRepo) DeleteConversation(ctx context.Context, conversationID string) error {
+	ret := _m.Called(ctx, conversationID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteConversation")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, conversationID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockUserRepo_DeleteConversation_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteConversation'
+type MockUserRepo_DeleteConversation_Call struct {
+	*mock.Call
+}
+
+// DeleteConversation is a helper method to define mock.On call
+//   - ctx context.Context
+//   - conversationID string
+func (_e *MockUserRepo_Expecter) DeleteConversation(ctx interface{}, conversationID interface{}) *MockUserRepo_DeleteConversation_Call {
+	return &MockUserRepo_DeleteConversation_Call{Call: _e.mock.On("DeleteConversation", ctx, conversationID)}
+}
+
+func (_c *MockUserRepo_DeleteConversation_Call) Run(run func(ctx context.Context, conversationID string)) *MockUserRepo_DeleteConversation_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockUserRepo_DeleteConversation_Call) Return(_a0 error) *MockUserRepo_DeleteConversation_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockUserRepo_DeleteConversation_Call) RunAndReturn(run func(context.Context, string) error) *MockUserRepo_DeleteConversation_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAPIKeys provides a mock function with given fields: ctx, userID
 func (_m *MockUserRepo) GetAPIKeys(ctx context.Context, userID string) ([]string, error) {
 	ret := _m.Called(ctx, userID)

--- a/pkg/repo/user.go
+++ b/pkg/repo/user.go
@@ -137,3 +137,15 @@ func (u *User) GetConversation(ctx context.Context, conversationID string) (*con
 
 	return &conversation, nil
 }
+
+// DeleteConversation removes a conversation from the Redis store by its ID.
+func (u *User) DeleteConversation(ctx context.Context, conversationID string) error {
+	redisKey := u.keyPrefix + convKeyPrefix + conversationID
+
+	res := u.db.Del(ctx, redisKey)
+	if res.Err() != nil {
+		return fmt.Errorf("failed to delete conversation: %w", res.Err())
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request introduces a new feature to reset user conversations and includes related changes across multiple files. It adds a `/cancel` command to reset conversations, implements the necessary backend logic, and ensures consistent handling of user IDs in commands.

### New Feature: Reset User Conversations

* **Added `ResetConversation` method to `TokenService` interface**: Enables resetting conversations for a user. (`pkg/bot/bot.go`, [pkg/bot/bot.goR36](diffhunk://#diff-214d9685a0938c2640632e2eb8020682100bafc612e4664e9c22f42650c4aee0R36))
* **Implemented `ResetConversation` in `Service`**: Deletes the user's conversation using the `UserRepo`. (`pkg/core/svc.go`, [pkg/core/svc.goR49-R57](diffhunk://#diff-3417b78b4c53da291253217e83c20a5aa880d70b184e632ce61fda2a7289c90aR49-R57))
* **Added `DeleteConversation` method to `UserRepo`**: Removes conversations from the Redis store. (`pkg/core/svc.go`, [[1]](diffhunk://#diff-3417b78b4c53da291253217e83c20a5aa880d70b184e632ce61fda2a7289c90aR23); `pkg/repo/user.go`, [[2]](diffhunk://#diff-c19d1b822d6df342c38fe7fdaa36a82d8c86a4978f266eb944049d9219fffe45R140-R151)

### Command Enhancements

* **Added `/cancel` command**: Resets the current conversation and informs the user. (`pkg/bot/handlers.go`, [pkg/bot/handlers.goR120-R125](diffhunk://#diff-184f1d998697a98b98d21d5887716d5a4ee0a93c325c43644c172093bd6c32c3R120-R125))
* **Reset conversation on `/start` command**: Ensures a fresh start for the user. (`pkg/bot/handlers.go`, [pkg/bot/handlers.goR88-R100](diffhunk://#diff-184f1d998697a98b98d21d5887716d5a4ee0a93c325c43644c172093bd6c32c3R88-R100))

### Refactoring for Consistency

* **Standardized user ID handling**: Replaced inline `fmt.Sprintf` calls with a single `userID` variable for clarity and reusability. (`pkg/bot/handlers.go`, [[1]](diffhunk://#diff-184f1d998697a98b98d21d5887716d5a4ee0a93c325c43644c172093bd6c32c3R88-R100) [[2]](diffhunk://#diff-184f1d998697a98b98d21d5887716d5a4ee0a93c325c43644c172093bd6c32c3L103-R110)