### PR TITLE
Document MIT_URL requirement for host IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ The telegram bot service consists of two main components deployed as a Docker Sw
 
 #### Secret Variables (GitHub Secrets)
 - `BOT_TOKEN` - Telegram bot token from [@BotFather](https://t.me/botfather)
-- `MIT_URL` - Make It Public API URL (e.g., `http://167.172.190.133:8082`)
+- `MIT_URL` - Make It Public API URL (must use host IP: `http://167.172.190.133:8082`)
+  - **Note**: Use the host IP address, not hostname, because the bot runs in an isolated overlay network and needs to access the API via the host's exposed port
 - `HOST` - Deployment server hostname/IP
 - `USERNAME` - SSH username for deployment
 - `PORT` - SSH port for deployment


### PR DESCRIPTION
## Summary

Clarifies the MIT_URL configuration requirement to prevent connection timeout errors.

## Changes

- Add note to README explaining that MIT_URL must use the host IP address (not hostname)
- Document the reason: bot runs in isolated Docker overlay network and needs to access the API via host's exposed port

## Background

After deployment, the bot was experiencing connection timeouts when MIT_URL was set to `http://make-it-public.dev:8082`. The issue was that from within the Docker Swarm overlay network, the bot container cannot resolve the hostname to reach the host machine.

## Solution

The MIT_URL must be set to `http://167.172.190.133:8082` (using the host IP address) so the bot can properly access the make-it-public API through the host network's exposed port 8082.

## Verification

After updating the GitHub secret to use the host IP, the bot successfully connects to the API with no errors.