### PR TITLE
feat: support up to 3 API keys per user with list and selective revoke

### DIFF
--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -31,16 +31,17 @@ type Config struct {
 
 type TokenService interface {
 	CreateToken(ctx context.Context, userID string) (*core.Response, error)
-	RevokeToken(ctx context.Context, userID string) error
+	RevokeToken(ctx context.Context, userID string) (*core.Response, error)
+	ListTokens(ctx context.Context, userID string) (*core.Response, error)
 	HandleMessage(ctx context.Context, userID string, message string) (*core.Response, error)
 	ResetConversation(ctx context.Context, userID string) error
 }
 
 type Service struct {
-	token    string
 	tg       tgClient
 	tokenSvc TokenService
 	handler  Handler
+	token    string
 }
 
 // New initializes a new Service with the given configuration and returns an error if the configuration is invalid.

--- a/pkg/bot/bot_test.go
+++ b/pkg/bot/bot_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestNew(t *testing.T) {
 	tests := []struct {
-		name    string
 		cfg     *Config
+		name    string
 		wantErr bool
 	}{
 		{
@@ -295,9 +295,9 @@ func TestProcessUpdate(t *testing.T) {
 	svc.handler = svc
 
 	tests := []struct {
-		name       string
 		update     *tgbotapi.Update
 		setupMocks func()
+		name       string
 	}{
 		{
 			name: "nil message",

--- a/pkg/bot/token_service_mock.go
+++ b/pkg/bot/token_service_mock.go
@@ -143,6 +143,65 @@ func (_c *MockTokenService_HandleMessage_Call) RunAndReturn(run func(context.Con
 	return _c
 }
 
+// ListTokens provides a mock function with given fields: ctx, userID
+func (_m *MockTokenService) ListTokens(ctx context.Context, userID string) (*core.Response, error) {
+	ret := _m.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListTokens")
+	}
+
+	var r0 *core.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*core.Response, error)); ok {
+		return rf(ctx, userID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *core.Response); ok {
+		r0 = rf(ctx, userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTokenService_ListTokens_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListTokens'
+type MockTokenService_ListTokens_Call struct {
+	*mock.Call
+}
+
+// ListTokens is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *MockTokenService_Expecter) ListTokens(ctx interface{}, userID interface{}) *MockTokenService_ListTokens_Call {
+	return &MockTokenService_ListTokens_Call{Call: _e.mock.On("ListTokens", ctx, userID)}
+}
+
+func (_c *MockTokenService_ListTokens_Call) Run(run func(ctx context.Context, userID string)) *MockTokenService_ListTokens_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockTokenService_ListTokens_Call) Return(_a0 *core.Response, _a1 error) *MockTokenService_ListTokens_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTokenService_ListTokens_Call) RunAndReturn(run func(context.Context, string) (*core.Response, error)) *MockTokenService_ListTokens_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ResetConversation provides a mock function with given fields: ctx, userID
 func (_m *MockTokenService) ResetConversation(ctx context.Context, userID string) error {
 	ret := _m.Called(ctx, userID)
@@ -191,21 +250,33 @@ func (_c *MockTokenService_ResetConversation_Call) RunAndReturn(run func(context
 }
 
 // RevokeToken provides a mock function with given fields: ctx, userID
-func (_m *MockTokenService) RevokeToken(ctx context.Context, userID string) error {
+func (_m *MockTokenService) RevokeToken(ctx context.Context, userID string) (*core.Response, error) {
 	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RevokeToken")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+	var r0 *core.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*core.Response, error)); ok {
+		return rf(ctx, userID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *core.Response); ok {
 		r0 = rf(ctx, userID)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.Response)
+		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // MockTokenService_RevokeToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RevokeToken'
@@ -227,12 +298,12 @@ func (_c *MockTokenService_RevokeToken_Call) Run(run func(ctx context.Context, u
 	return _c
 }
 
-func (_c *MockTokenService_RevokeToken_Call) Return(_a0 error) *MockTokenService_RevokeToken_Call {
-	_c.Call.Return(_a0)
+func (_c *MockTokenService_RevokeToken_Call) Return(_a0 *core.Response, _a1 error) *MockTokenService_RevokeToken_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockTokenService_RevokeToken_Call) RunAndReturn(run func(context.Context, string) error) *MockTokenService_RevokeToken_Call {
+func (_c *MockTokenService_RevokeToken_Call) RunAndReturn(run func(context.Context, string) (*core.Response, error)) *MockTokenService_RevokeToken_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -12,9 +12,9 @@ import (
 )
 
 type appConfig struct {
+	Repo repo.Config `mapstructure:"repo"`
 	Bot  bot.Config  `mapstructure:"bot"`
 	MIT  prov.Config `mapstructure:"mit"`
-	Repo repo.Config `mapstructure:"repo"`
 }
 
 // loadConfig loads the application configuration using the provided arguments and environment variables.

--- a/pkg/core/conv/conv.go
+++ b/pkg/core/conv/conv.go
@@ -18,6 +18,7 @@ const (
 
 type Question struct {
 	Text    string   `json:"text"`
+	Field   string   `json:"field,omitempty"`
 	Answers []string `json:"answers,omitempty"`
 }
 

--- a/pkg/core/conv/conv_test.go
+++ b/pkg/core/conv/conv_test.go
@@ -66,9 +66,9 @@ func TestConversation_Start(t *testing.T) {
 
 func TestConversation_Current(t *testing.T) {
 	tests := []struct {
-		name    string
 		conv    *Conversation
 		want    *Question
+		name    string
 		wantErr bool
 	}{
 		{

--- a/pkg/core/conv/questions.go
+++ b/pkg/core/conv/questions.go
@@ -46,6 +46,7 @@ func (f *Questions) ProcessAnswer(answer string) (bool, error) {
 	for _, a := range answers {
 		if a == answer {
 			f.QAPairs[f.Position].Answer = answer
+			f.QAPairs[f.Position].Field = f.QAPairs[f.Position].Question.Field
 			f.Position++
 			return f.Position >= len(f.QAPairs), nil
 		}

--- a/pkg/core/conv/questions_test.go
+++ b/pkg/core/conv/questions_test.go
@@ -31,11 +31,11 @@ func TestNewQuestions(t *testing.T) {
 
 func TestQuestions_GetQuestion(t *testing.T) {
 	tests := []struct {
+		errType error
+		want    *Question
 		name    string
 		qs      Questions
-		want    *Question
 		wantErr bool
-		errType error
 	}{
 		{
 			name: "get first question",
@@ -94,12 +94,12 @@ func TestQuestions_GetQuestion(t *testing.T) {
 func TestQuestions_ProcessAnswer(t *testing.T) {
 	tests := []struct {
 		name       string
-		qs         Questions
 		answer     string
+		wantAnswer string
+		qs         Questions
+		wantPos    int
 		wantDone   bool
 		wantErr    bool
-		wantPos    int
-		wantAnswer string
 	}{
 		{
 			name: "process valid answer - not done",
@@ -174,11 +174,11 @@ func TestQuestions_ProcessAnswer(t *testing.T) {
 
 func TestQuestions_GetResults(t *testing.T) {
 	tests := []struct {
-		name    string
-		qs      Questions
-		want    []QuestionAnswer
-		wantErr bool
 		errType error
+		name    string
+		want    []QuestionAnswer
+		qs      Questions
+		wantErr bool
 	}{
 		{
 			name: "get results - complete",

--- a/pkg/core/create_token.go
+++ b/pkg/core/create_token.go
@@ -10,23 +10,28 @@ import (
 )
 
 const (
-	maxTokensPerUser    = 1
+	maxTokensPerUser    = 3
 	secondsInDay        = 24 * 60 * 60
 	tokenCreatedMessage = "🔑 Your New API Token\n\n%s\n\n⏱ Valid until: %s\n\nKeep this token secure and don't share it with others."
+	keyIDDisplayLen     = 8 // Number of characters shown from key ID in buttons
 )
 
 const (
-	StateTokenRegenerate conv.State = "tokenRegenerate"
-	StateTokenExists     conv.State = "tokenExists"
-	StateNewToken        conv.State = "newToken"
+	StateTokenRegenerate         conv.State = "tokenRegenerate"
+	StateTokenExists             conv.State = "tokenExists"
+	StateNewToken                conv.State = "newToken"
+	StateSelectTokenToRegenerate conv.State = "selectTokenToRegenerate"
+	StateSelectTokenToRevoke     conv.State = "selectTokenToRevoke"
 )
 
 var (
 	ErrInvalidExpirationPeriod = fmt.Errorf("invalid expiration period selected")
+	ErrKeyNotFound             = fmt.Errorf("selected key not found")
 )
 
-// CreateToken generates a new API token for the specified user, storing it in the repository, if token limits are not exceeded.
-// Returns an error if the token limit is reached, fails to generate the token, or fails to save the token in the repository.
+// CreateToken generates a new API token for the specified user, storing it in the repository.
+// If the user is at the token limit, it starts a conversation to choose an existing token to regenerate.
+// Returns an error if token fetching fails or if starting the conversation fails.
 func (s *Service) CreateToken(ctx context.Context, userID string) (*Response, error) {
 	keys, err := s.repo.GetAPIKeys(ctx, userID)
 	if err != nil {
@@ -34,38 +39,43 @@ func (s *Service) CreateToken(ctx context.Context, userID string) (*Response, er
 	}
 
 	if len(keys) >= maxTokensPerUser {
-		c, err := s.repo.GetConversation(ctx, userID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get conversation: %w", err)
-		}
-
-		questions := conv.NewQuestions(
-			[]conv.Question{{
-				Text:    "You already have an active API token. Do you want to regenerate it?",
-				Answers: []string{"Yes", "No"},
-			}},
-		)
-
-		if err := c.Start(StateTokenExists, questions); err != nil {
-			return nil, fmt.Errorf("failed to start questions: %w", err)
-		}
-
-		q, _ := c.Current()
-
-		if err := s.repo.SaveConversation(ctx, c); err != nil {
-			return nil, fmt.Errorf("failed to save conversation: %w", err)
-		}
-
-		return &Response{
-			Message: q.Text,
-			Answers: q.Answers,
-		}, nil
+		return s.askToRegenerateToken(ctx, userID)
 	}
 
 	return s.askForTokenExpiration(ctx, userID, StateNewToken)
 }
 
-// handleTokenExistsResult processes the result of a "token exists" question and takes appropriate action based on the answer.
+// askToRegenerateToken starts a conversation asking the user whether they want to regenerate one of their existing tokens.
+func (s *Service) askToRegenerateToken(ctx context.Context, userID string) (*Response, error) {
+	c, err := s.repo.GetConversation(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get conversation: %w", err)
+	}
+
+	questions := conv.NewQuestions(
+		[]conv.Question{{
+			Text:    fmt.Sprintf("You've reached the maximum of %d API tokens. Do you want to regenerate an existing one?", maxTokensPerUser),
+			Answers: []string{"Yes", "No"},
+		}},
+	)
+
+	if err := c.Start(StateTokenExists, questions); err != nil {
+		return nil, fmt.Errorf("failed to start questions: %w", err)
+	}
+
+	q, _ := c.Current()
+
+	if err := s.repo.SaveConversation(ctx, c); err != nil {
+		return nil, fmt.Errorf("failed to save conversation: %w", err)
+	}
+
+	return &Response{
+		Message: q.Text,
+		Answers: q.Answers,
+	}, nil
+}
+
+// handleTokenExistsResult processes the answer to "do you want to regenerate?" and takes appropriate action.
 func (s *Service) handleTokenExistsResult(ctx context.Context, userID string, answers []conv.QuestionAnswer) (*Response, error) {
 	if len(answers) != 1 {
 		return nil, fmt.Errorf("expected exactly one answer for tokenExists question, got %d", len(answers))
@@ -73,13 +83,100 @@ func (s *Service) handleTokenExistsResult(ctx context.Context, userID string, an
 
 	if answers[0].Answer == "No" {
 		return &Response{
-			Message: "No changes made. You can continue using your existing API token.",
+			Message: "No changes made. You can continue using your existing API tokens.",
 		}, nil
 	}
 
-	return s.askForTokenExpiration(ctx, userID, StateTokenRegenerate)
+	return s.askToSelectTokenForRegeneration(ctx, userID)
 }
 
+// askToSelectTokenForRegeneration starts a conversation asking the user which token to regenerate.
+func (s *Service) askToSelectTokenForRegeneration(ctx context.Context, userID string) (*Response, error) {
+	keys, err := s.repo.GetAPIKeysWithExpiration(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get API keys: %w", err)
+	}
+
+	q := buildTokenSelectionQuestion(keys, "Which token do you want to regenerate?")
+
+	c, err := s.repo.GetConversation(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get conversation: %w", err)
+	}
+
+	questions := conv.NewQuestions([]conv.Question{q})
+
+	if err := c.Start(StateSelectTokenToRegenerate, questions); err != nil {
+		return nil, fmt.Errorf("failed to start questions: %w", err)
+	}
+
+	current, _ := c.Current()
+
+	if err := s.repo.SaveConversation(ctx, c); err != nil {
+		return nil, fmt.Errorf("failed to save conversation: %w", err)
+	}
+
+	return &Response{
+		Message: current.Text,
+		Answers: current.Answers,
+	}, nil
+}
+
+// handleSelectTokenToRegenerateResult stores the selected key ID context and asks for the new expiration period.
+func (s *Service) handleSelectTokenToRegenerateResult(ctx context.Context, userID string, answers []conv.QuestionAnswer) (*Response, error) {
+	if len(answers) != 1 {
+		return nil, fmt.Errorf("expected exactly one answer for token selection question, got %d", len(answers))
+	}
+
+	selectedPrefix := answers[0].Answer
+
+	// Resolve the full key ID from the prefix
+	keys, err := s.repo.GetAPIKeys(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get API keys: %w", err)
+	}
+
+	keyID, err := resolveKeyIDFromPrefix(keys, selectedPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve key ID: %w", err)
+	}
+
+	return s.askForTokenExpirationWithKeyID(ctx, userID, StateTokenRegenerate, keyID)
+}
+
+// askForTokenExpirationWithKeyID starts a conversation asking the user for an expiration period,
+// embedding the target keyID in the question field for later use.
+func (s *Service) askForTokenExpirationWithKeyID(ctx context.Context, userID string, state conv.State, keyID string) (*Response, error) {
+	c, err := s.repo.GetConversation(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get conversation: %w", err)
+	}
+
+	questions := conv.NewQuestions(
+		[]conv.Question{{
+			Text:    "What is the expiration period for your new API token?",
+			Answers: []string{"1 day", "7 days", "30 days", "90 days"},
+			Field:   keyID,
+		}},
+	)
+
+	if err := c.Start(state, questions); err != nil {
+		return nil, fmt.Errorf("failed to start questions: %w", err)
+	}
+
+	q, _ := c.Current()
+
+	if err := s.repo.SaveConversation(ctx, c); err != nil {
+		return nil, fmt.Errorf("failed to save conversation: %w", err)
+	}
+
+	return &Response{
+		Message: q.Text,
+		Answers: q.Answers,
+	}, nil
+}
+
+// handleNewTokenResult creates a brand-new token with the chosen expiration period.
 func (s *Service) handleNewTokenResult(ctx context.Context, userID string, answers []conv.QuestionAnswer) (*Response, error) {
 	expiresIn, err := s.parseExpirationAnswer(answers)
 
@@ -102,11 +199,14 @@ func (s *Service) handleNewTokenResult(ctx context.Context, userID string, answe
 	}
 
 	expiresAt := time.Now().Add(token.ExpiresIn).Format(time.DateTime)
+
 	return &Response{
 		Message: fmt.Sprintf(tokenCreatedMessage, token.Token, expiresAt),
 	}, nil
 }
 
+// handleTokenRegenerateResult revokes the previously selected token and generates a new one.
+// The key ID to revoke is stored in the Field of the expiration question answer.
 func (s *Service) handleTokenRegenerateResult(ctx context.Context, userID string, answers []conv.QuestionAnswer) (*Response, error) {
 	expiresIn, err := s.parseExpirationAnswer(answers)
 
@@ -119,16 +219,15 @@ func (s *Service) handleTokenRegenerateResult(ctx context.Context, userID string
 		return nil, fmt.Errorf("failed to parse expiration answer: %w", err)
 	}
 
-	keys, err := s.repo.GetAPIKeys(ctx, userID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get API keys: %w", err)
+	if len(answers) == 0 {
+		return nil, fmt.Errorf("expected at least one answer, got none")
 	}
 
-	if len(keys) != 1 {
-		return nil, fmt.Errorf("expected exactly one API key for user %s, got %d", userID, len(keys))
+	keyID := answers[0].Field
+	if keyID == "" {
+		return nil, fmt.Errorf("missing key ID in regenerate answer field")
 	}
 
-	keyID := keys[0]
 	if err := s.prov.RevokeToken(keyID); err != nil {
 		return nil, fmt.Errorf("failed to revoke existing token: %w", err)
 	}
@@ -147,45 +246,25 @@ func (s *Service) handleTokenRegenerateResult(ctx context.Context, userID string
 	}
 
 	expiresAt := time.Now().Add(token.ExpiresIn).Format(time.DateTime)
+
 	return &Response{
 		Message: fmt.Sprintf(tokenCreatedMessage, token.Token, expiresAt),
 	}, nil
 }
 
+// askForTokenExpiration starts a conversation asking for token expiration period (no associated key ID).
 func (s *Service) askForTokenExpiration(ctx context.Context, userID string, state conv.State) (*Response, error) {
-	c, err := s.repo.GetConversation(ctx, userID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get conversation: %w", err)
-	}
-
-	questions := conv.NewQuestions(
-		[]conv.Question{{
-			Text:    "What is the expiration period for your new API token?",
-			Answers: []string{"1 day", "7 days", "30 days", "90 days"},
-		}},
-	)
-
-	if err := c.Start(state, questions); err != nil {
-		return nil, fmt.Errorf("failed to start questions: %w", err)
-	}
-
-	q, _ := c.Current()
-	if err := s.repo.SaveConversation(ctx, c); err != nil {
-		return nil, fmt.Errorf("failed to save conversation: %w", err)
-	}
-
-	return &Response{
-		Message: q.Text,
-		Answers: q.Answers,
-	}, nil
+	return s.askForTokenExpirationWithKeyID(ctx, userID, state, "")
 }
 
+// parseExpirationAnswer converts the user's textual expiration answer to a seconds value.
 func (s *Service) parseExpirationAnswer(answers []conv.QuestionAnswer) (int64, error) {
-	if len(answers) != 1 {
-		return 0, fmt.Errorf("expected exactly one answer for expiration question, got %d", len(answers))
+	if len(answers) == 0 {
+		return 0, fmt.Errorf("expected at least one answer for expiration question, got 0")
 	}
 
 	var expiresIn int64
+
 	switch answers[0].Answer {
 	case "1 day":
 		expiresIn = secondsInDay
@@ -200,4 +279,40 @@ func (s *Service) parseExpirationAnswer(answers []conv.QuestionAnswer) (int64, e
 	}
 
 	return expiresIn, nil
+}
+
+// buildTokenSelectionQuestion creates a Question that lists all provided keys as selectable buttons.
+// The button text is the first keyIDDisplayLen characters of the key ID, plus expiration date.
+func buildTokenSelectionQuestion(keys []KeyInfo, questionText string) conv.Question {
+	answers := make([]string, len(keys))
+	for i, k := range keys {
+		prefix := k.KeyID
+		if len(prefix) > keyIDDisplayLen {
+			prefix = prefix[:keyIDDisplayLen]
+		}
+
+		answers[i] = fmt.Sprintf("%s (exp: %s)", prefix, k.ExpiresAt.Format("2006-01-02"))
+	}
+
+	return conv.Question{
+		Text:    questionText,
+		Answers: answers,
+	}
+}
+
+// resolveKeyIDFromPrefix finds the full key ID whose prefix matches the button text selected by the user.
+// The button text format is "<prefix> (exp: <date>)".
+func resolveKeyIDFromPrefix(keys []string, buttonText string) (string, error) {
+	for _, k := range keys {
+		prefix := k
+		if len(prefix) > keyIDDisplayLen {
+			prefix = prefix[:keyIDDisplayLen]
+		}
+
+		if len(buttonText) >= keyIDDisplayLen && buttonText[:keyIDDisplayLen] == prefix {
+			return k, nil
+		}
+	}
+
+	return "", ErrKeyNotFound
 }

--- a/pkg/core/create_token_test.go
+++ b/pkg/core/create_token_test.go
@@ -14,109 +14,52 @@ import (
 
 func TestCreateToken(t *testing.T) {
 	tests := []struct {
-		name           string
-		userID         string
-		existingKeys   []string
-		getKeysErr     error
-		token          *APIToken
-		generateErr    error
-		addKeyErr      error
-		saveConvErr    error
-		expectedResp   *Response
-		expectedErr    error
-		expectAddKey   bool
-		expectSaveConv bool
+		getKeysErr      error
+		saveConvErr     error
+		name            string
+		userID          string
+		expectedMsg     string
+		expectedErr     string
+		existingKeys    []string
+		expectedAnswers []string
+		expectSaveConv  bool
 	}{
 		{
-			name:         "success",
-			userID:       "user123",
-			existingKeys: []string{},
-			getKeysErr:   nil,
-			token: &APIToken{
-				KeyID:     "key123",
-				Token:     "token123",
-				ExpiresIn: time.Hour,
-			},
-			generateErr:    nil,
-			addKeyErr:      nil,
-			saveConvErr:    nil,
-			expectedResp:   &Response{Message: "What is the expiration period for your new API token?", Answers: []string{"1 day", "7 days", "30 days", "90 days"}},
-			expectedErr:    nil,
-			expectAddKey:   true,
-			expectSaveConv: false,
+			name:            "under limit - asks for expiration",
+			userID:          "user123",
+			existingKeys:    []string{},
+			expectedMsg:     "What is the expiration period for your new API token?",
+			expectedAnswers: []string{"1 day", "7 days", "30 days", "90 days"},
+			expectSaveConv:  true,
 		},
 		{
-			name:           "token exists",
+			name:            "at limit - asks to regenerate",
+			userID:          "user123",
+			existingKeys:    []string{"key1", "key2", "key3"},
+			expectedMsg:     "You've reached the maximum of 3 API tokens. Do you want to regenerate an existing one?",
+			expectedAnswers: []string{"Yes", "No"},
+			expectSaveConv:  true,
+		},
+		{
+			name:        "get keys error",
+			userID:      "user123",
+			getKeysErr:  errors.New("get keys error"),
+			expectedErr: "failed to get API keys: get keys error",
+		},
+		{
+			name:           "save conversation error when at limit",
 			userID:         "user123",
-			existingKeys:   []string{"existing-key"},
-			getKeysErr:     nil,
-			token:          nil,
-			generateErr:    nil,
-			addKeyErr:      nil,
-			saveConvErr:    nil,
-			expectedResp:   &Response{Message: "You already have an active API token. Do you want to regenerate it?", Answers: []string{"Yes", "No"}},
-			expectedErr:    nil,
-			expectAddKey:   false,
+			existingKeys:   []string{"key1", "key2", "key3"},
+			saveConvErr:    errors.New("save conversation error"),
+			expectedErr:    "failed to save conversation: save conversation error",
 			expectSaveConv: true,
 		},
 		{
-			name:           "get keys error",
-			userID:         "user123",
-			existingKeys:   nil,
-			getKeysErr:     errors.New("get keys error"),
-			token:          nil,
-			generateErr:    nil,
-			addKeyErr:      nil,
-			saveConvErr:    nil,
-			expectedResp:   nil,
-			expectedErr:    errors.New("failed to get API keys: get keys error"),
-			expectAddKey:   false,
-			expectSaveConv: false,
-		},
-		{
-			name:           "generate token error",
+			name:           "save conversation error when under limit",
 			userID:         "user123",
 			existingKeys:   []string{},
-			getKeysErr:     nil,
-			token:          nil,
-			generateErr:    errors.New("generate token error"),
-			addKeyErr:      nil,
-			saveConvErr:    nil,
-			expectedResp:   &Response{Message: "What is the expiration period for your new API token?", Answers: []string{"1 day", "7 days", "30 days", "90 days"}},
-			expectedErr:    nil,
-			expectAddKey:   false,
-			expectSaveConv: false,
-		},
-		{
-			name:         "add key error",
-			userID:       "user123",
-			existingKeys: []string{},
-			getKeysErr:   nil,
-			token: &APIToken{
-				KeyID:     "key123",
-				Token:     "token123",
-				ExpiresIn: time.Hour,
-			},
-			generateErr:    nil,
-			addKeyErr:      errors.New("add key error"),
-			saveConvErr:    nil,
-			expectedResp:   &Response{Message: "What is the expiration period for your new API token?", Answers: []string{"1 day", "7 days", "30 days", "90 days"}},
-			expectedErr:    nil,
-			expectAddKey:   true,
-			expectSaveConv: false,
-		},
-		{
-			name:           "save conversation error",
-			userID:         "user123",
-			existingKeys:   []string{"existing-key"},
-			getKeysErr:     nil,
-			token:          nil,
-			generateErr:    nil,
-			addKeyErr:      nil,
 			saveConvErr:    errors.New("save conversation error"),
-			expectedResp:   nil,
-			expectedErr:    errors.New("failed to save conversation: save conversation error"),
-			expectAddKey:   false,
+			expectedErr:    "failed to save conversation: save conversation error",
 			expectSaveConv: true,
 		},
 	}
@@ -128,43 +71,27 @@ func TestCreateToken(t *testing.T) {
 
 			repo.On("GetAPIKeys", mock.Anything, tt.userID).Return(tt.existingKeys, tt.getKeysErr)
 
-			// Mock GetConversation for all test cases
-			// We don't care how many times it's called
-			repo.On("GetConversation", mock.Anything, tt.userID).Return(conv.New(tt.userID), nil).Maybe()
+			if tt.getKeysErr == nil {
+				repo.On("GetConversation", mock.Anything, tt.userID).Return(conv.New(tt.userID), nil).Maybe()
 
-			// Mock SaveConversation for all test cases where we create a new token
-			if tt.existingKeys != nil && len(tt.existingKeys) == 0 {
-				repo.On("SaveConversation", mock.Anything, mock.MatchedBy(func(c *conv.Conversation) bool {
-					return c.ID == tt.userID && c.State == "newToken"
-				})).Return(tt.saveConvErr)
-			}
-
-			if tt.expectSaveConv {
-				// Create a matcher function that validates the conversation object
-				repo.On("SaveConversation", mock.Anything, mock.MatchedBy(func(c *conv.Conversation) bool {
-					// Verify that the conversation has the correct user ID and state
-					return c.ID == tt.userID && c.State == "tokenExists"
-				})).Return(tt.saveConvErr)
+				if tt.expectSaveConv {
+					repo.On("SaveConversation", mock.Anything, mock.AnythingOfType("*conv.Conversation")).Return(tt.saveConvErr)
+				}
 			}
 
 			svc := New(repo, prov)
 
 			resp, err := svc.CreateToken(context.Background(), tt.userID)
 
-			if tt.expectedErr != nil {
-				assert.Error(t, err)
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectedErr, err.Error())
 				assert.Nil(t, resp)
-				if tt.expectedErr.Error() != "" {
-					assert.Equal(t, tt.expectedErr.Error(), err.Error())
-				}
 			} else {
-				assert.NoError(t, err)
-				if tt.expectedResp != nil {
-					assert.Equal(t, tt.expectedResp.Message, resp.Message)
-					assert.Equal(t, tt.expectedResp.Answers, resp.Answers)
-				} else {
-					assert.Nil(t, resp)
-				}
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Equal(t, tt.expectedMsg, resp.Message)
+				assert.Equal(t, tt.expectedAnswers, resp.Answers)
 			}
 
 			repo.AssertExpectations(t)
@@ -177,88 +104,25 @@ func TestHandleTokenExistsResult(t *testing.T) {
 	tests := []struct {
 		name            string
 		userID          string
-		answers         []conv.QuestionAnswer
-		createTokenResp *Response
-		createTokenErr  error
-		expectedResp    *Response
+		expectedMsg     string
 		expectedErr     string
+		answers         []conv.QuestionAnswer
+		expectedAnswers []string
 	}{
 		{
 			name:   "answer is No",
 			userID: "user123",
 			answers: []conv.QuestionAnswer{
-				{
-					Question: conv.Question{
-						Text:    "You already have an active API token. Do you want to regenerate it?",
-						Answers: []string{"Yes", "No"},
-					},
-					Answer: "No",
-				},
+				{Answer: "No"},
 			},
-			expectedResp: &Response{
-				Message: "No changes made. You can continue using your existing API token.",
-			},
-		},
-		{
-			name:   "answer is Yes - success",
-			userID: "user123",
-			answers: []conv.QuestionAnswer{
-				{
-					Question: conv.Question{
-						Text:    "You already have an active API token. Do you want to regenerate it?",
-						Answers: []string{"Yes", "No"},
-					},
-					Answer: "Yes",
-				},
-			},
-			createTokenResp: &Response{
-				Message: "What is the expiration period for your new API token?",
-				Answers: []string{"1 day", "7 days", "30 days", "90 days"},
-			},
-			expectedResp: &Response{
-				Message: "What is the expiration period for your new API token?",
-				Answers: []string{"1 day", "7 days", "30 days", "90 days"},
-			},
-		},
-		{
-			name:   "answer is Yes - create token error",
-			userID: "user123",
-			answers: []conv.QuestionAnswer{
-				{
-					Question: conv.Question{
-						Text:    "You already have an active API token. Do you want to regenerate it?",
-						Answers: []string{"Yes", "No"},
-					},
-					Answer: "Yes",
-				},
-			},
-			createTokenResp: &Response{
-				Message: "What is the expiration period for your new API token?",
-				Answers: []string{"1 day", "7 days", "30 days", "90 days"},
-			},
-			expectedResp: &Response{
-				Message: "What is the expiration period for your new API token?",
-				Answers: []string{"1 day", "7 days", "30 days", "90 days"},
-			},
+			expectedMsg: "No changes made. You can continue using your existing API tokens.",
 		},
 		{
 			name:   "invalid number of answers",
 			userID: "user123",
 			answers: []conv.QuestionAnswer{
-				{
-					Question: conv.Question{
-						Text:    "Question 1",
-						Answers: []string{"Answer 1", "Answer 2"},
-					},
-					Answer: "Answer 1",
-				},
-				{
-					Question: conv.Question{
-						Text:    "Question 2",
-						Answers: []string{"Answer 1", "Answer 2"},
-					},
-					Answer: "Answer 2",
-				},
+				{Answer: "Yes"},
+				{Answer: "No"},
 			},
 			expectedErr: "expected exactly one answer for tokenExists question, got 2",
 		},
@@ -269,21 +133,7 @@ func TestHandleTokenExistsResult(t *testing.T) {
 			repo := NewMockUserRepo(t)
 			prov := NewMockMITProv(t)
 
-			// Create a partial mock of Service to mock CreateToken
 			svc := New(repo, prov)
-
-			// Setup conversation mocking for all test cases
-			conversation := conv.New(tt.userID)
-
-			// Setup mocks for tokenRegenerate state
-			if tt.answers[0].Answer == "Yes" {
-				repo.On("GetConversation", mock.Anything, tt.userID).Return(conversation, nil)
-
-				// Mock SaveConversation for tokenRegenerate state
-				repo.On("SaveConversation", mock.Anything, mock.MatchedBy(func(c *conv.Conversation) bool {
-					return c.ID == tt.userID && c.State == StateTokenRegenerate
-				})).Return(nil)
-			}
 
 			resp, err := svc.handleTokenExistsResult(context.Background(), tt.userID, tt.answers)
 
@@ -294,11 +144,281 @@ func TestHandleTokenExistsResult(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, resp)
-				assert.Equal(t, tt.expectedResp.Message, resp.Message)
+				assert.Equal(t, tt.expectedMsg, resp.Message)
 			}
 
 			repo.AssertExpectations(t)
 			prov.AssertExpectations(t)
 		})
 	}
+}
+
+func TestHandleTokenExistsResult_Yes(t *testing.T) {
+	userID := "user123"
+	keys := []KeyInfo{
+		{KeyID: "abcdef123456", ExpiresAt: time.Now().Add(24 * time.Hour)},
+		{KeyID: "xyz987654321", ExpiresAt: time.Now().Add(48 * time.Hour)},
+	}
+
+	repo := NewMockUserRepo(t)
+	prov := NewMockMITProv(t)
+
+	repo.On("GetAPIKeysWithExpiration", mock.Anything, userID).Return(keys, nil)
+	repo.On("GetConversation", mock.Anything, userID).Return(conv.New(userID), nil)
+	repo.On("SaveConversation", mock.Anything, mock.MatchedBy(func(c *conv.Conversation) bool {
+		return c.ID == userID && c.State == StateSelectTokenToRegenerate
+	})).Return(nil)
+
+	svc := New(repo, prov)
+
+	answers := []conv.QuestionAnswer{
+		{Answer: "Yes"},
+	}
+
+	resp, err := svc.handleTokenExistsResult(context.Background(), userID, answers)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "Which token do you want to regenerate?", resp.Message)
+	assert.Len(t, resp.Answers, 2)
+
+	repo.AssertExpectations(t)
+	prov.AssertExpectations(t)
+}
+
+func TestHandleNewTokenResult(t *testing.T) {
+	tests := []struct {
+		generateErr error
+		addKeyErr   error
+		token       *APIToken
+		name        string
+		userID      string
+		expectedMsg string
+		expectedErr string
+		answers     []conv.QuestionAnswer
+	}{
+		{
+			name:   "success - 7 days",
+			userID: "user123",
+			answers: []conv.QuestionAnswer{
+				{Answer: "7 days"},
+			},
+			token: &APIToken{
+				KeyID:     "key123",
+				Token:     "token123",
+				ExpiresIn: 7 * 24 * time.Hour,
+			},
+			expectedMsg: "Your New API Token",
+		},
+		{
+			name:   "invalid expiration period",
+			userID: "user123",
+			answers: []conv.QuestionAnswer{
+				{Answer: "invalid"},
+			},
+			expectedMsg: "Invalid expiration period selected.",
+		},
+		{
+			name:        "empty answers",
+			userID:      "user123",
+			answers:     []conv.QuestionAnswer{},
+			expectedErr: "expected at least one answer for expiration question, got 0",
+		},
+		{
+			name:   "generate token error",
+			userID: "user123",
+			answers: []conv.QuestionAnswer{
+				{Answer: "1 day"},
+			},
+			generateErr: errors.New("generate error"),
+			expectedErr: "failed to generate token: generate error",
+		},
+		{
+			name:   "add key error",
+			userID: "user123",
+			answers: []conv.QuestionAnswer{
+				{Answer: "30 days"},
+			},
+			token: &APIToken{
+				KeyID:     "key123",
+				Token:     "token123",
+				ExpiresIn: 30 * 24 * time.Hour,
+			},
+			addKeyErr:   errors.New("add key error"),
+			expectedErr: "failed to add API key: add key error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := NewMockUserRepo(t)
+			prov := NewMockMITProv(t)
+
+			if tt.token != nil || tt.generateErr != nil {
+				prov.On("GenerateToken", "", mock.AnythingOfType("int64")).Return(tt.token, tt.generateErr)
+			}
+
+			if tt.token != nil && tt.generateErr == nil {
+				repo.On("AddAPIKey", mock.Anything, tt.userID, tt.token.KeyID, tt.token.ExpiresIn).Return(tt.addKeyErr)
+			}
+
+			svc := New(repo, prov)
+
+			resp, err := svc.handleNewTokenResult(context.Background(), tt.userID, tt.answers)
+
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+				assert.Nil(t, resp)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				assert.Contains(t, resp.Message, tt.expectedMsg)
+			}
+
+			repo.AssertExpectations(t)
+			prov.AssertExpectations(t)
+		})
+	}
+}
+
+func TestHandleTokenRegenerateResult(t *testing.T) {
+	userID := "user123"
+	keyID := "key123"
+
+	t.Run("success", func(t *testing.T) {
+		repo := NewMockUserRepo(t)
+		prov := NewMockMITProv(t)
+
+		token := &APIToken{
+			KeyID:     keyID,
+			Token:     "newtoken",
+			ExpiresIn: 7 * 24 * time.Hour,
+		}
+
+		prov.On("RevokeToken", keyID).Return(nil)
+		repo.On("RevokeToken", mock.Anything, userID, keyID).Return(nil)
+		prov.On("GenerateToken", keyID, mock.AnythingOfType("int64")).Return(token, nil)
+		repo.On("AddAPIKey", mock.Anything, userID, keyID, token.ExpiresIn).Return(nil)
+
+		svc := New(repo, prov)
+
+		answers := []conv.QuestionAnswer{
+			{Answer: "7 days", Field: keyID},
+		}
+
+		resp, err := svc.handleTokenRegenerateResult(context.Background(), userID, answers)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Contains(t, resp.Message, "Your New API Token")
+
+		repo.AssertExpectations(t)
+		prov.AssertExpectations(t)
+	})
+
+	t.Run("missing key ID in field", func(t *testing.T) {
+		svc := New(NewMockUserRepo(t), NewMockMITProv(t))
+
+		answers := []conv.QuestionAnswer{
+			{Answer: "7 days", Field: ""},
+		}
+
+		_, err := svc.handleTokenRegenerateResult(context.Background(), userID, answers)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing key ID")
+	})
+
+	t.Run("invalid expiration period", func(t *testing.T) {
+		svc := New(NewMockUserRepo(t), NewMockMITProv(t))
+
+		answers := []conv.QuestionAnswer{
+			{Answer: "invalid", Field: keyID},
+		}
+
+		resp, err := svc.handleTokenRegenerateResult(context.Background(), userID, answers)
+		require.NoError(t, err)
+		assert.Contains(t, resp.Message, "Invalid expiration period")
+	})
+}
+
+func TestHandleSelectTokenToRegenerateResult(t *testing.T) {
+	userID := "user123"
+	keyID := "abcdef123456"
+
+	t.Run("success", func(t *testing.T) {
+		repo := NewMockUserRepo(t)
+		prov := NewMockMITProv(t)
+
+		repo.On("GetAPIKeys", mock.Anything, userID).Return([]string{keyID}, nil)
+		repo.On("GetConversation", mock.Anything, userID).Return(conv.New(userID), nil)
+		repo.On("SaveConversation", mock.Anything, mock.MatchedBy(func(c *conv.Conversation) bool {
+			return c.State == StateTokenRegenerate
+		})).Return(nil)
+
+		svc := New(repo, prov)
+
+		answers := []conv.QuestionAnswer{
+			{Answer: keyID[:keyIDDisplayLen] + " (exp: 2026-03-01)"},
+		}
+
+		resp, err := svc.handleSelectTokenToRegenerateResult(context.Background(), userID, answers)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "What is the expiration period for your new API token?", resp.Message)
+
+		repo.AssertExpectations(t)
+		prov.AssertExpectations(t)
+	})
+
+	t.Run("wrong number of answers", func(t *testing.T) {
+		svc := New(NewMockUserRepo(t), NewMockMITProv(t))
+		_, err := svc.handleSelectTokenToRegenerateResult(context.Background(), userID, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected exactly one answer")
+	})
+}
+
+func TestBuildTokenSelectionQuestion(t *testing.T) {
+	keys := []KeyInfo{
+		{KeyID: "abcdef12345678", ExpiresAt: time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)},
+		{KeyID: "xyz9876543210", ExpiresAt: time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)},
+	}
+
+	q := buildTokenSelectionQuestion(keys, "Pick one")
+
+	assert.Equal(t, "Pick one", q.Text)
+	assert.Len(t, q.Answers, 2)
+	assert.Contains(t, q.Answers[0], "abcdef12")
+	assert.Contains(t, q.Answers[0], "2026-03-15")
+	assert.Contains(t, q.Answers[1], "xyz98765")
+	assert.Contains(t, q.Answers[1], "2026-04-20")
+}
+
+func TestResolveKeyIDFromPrefix(t *testing.T) {
+	keys := []string{"abcdef12345678", "xyz9876543210"}
+
+	t.Run("match first key", func(t *testing.T) {
+		result, err := resolveKeyIDFromPrefix(keys, "abcdef12 (exp: 2026-03-15)")
+		require.NoError(t, err)
+		assert.Equal(t, "abcdef12345678", result)
+	})
+
+	t.Run("match second key", func(t *testing.T) {
+		result, err := resolveKeyIDFromPrefix(keys, "xyz98765 (exp: 2026-04-20)")
+		require.NoError(t, err)
+		assert.Equal(t, "xyz9876543210", result)
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		_, err := resolveKeyIDFromPrefix(keys, "nomatch1 (exp: 2026-03-15)")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrKeyNotFound)
+	})
+
+	t.Run("short button text", func(t *testing.T) {
+		_, err := resolveKeyIDFromPrefix(keys, "short")
+		require.Error(t, err)
+	})
 }

--- a/pkg/core/list_tokens.go
+++ b/pkg/core/list_tokens.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	listTokensHeader = "🔑 Your Active API Tokens (%d/%d)\n\n"
+	listTokensEntry  = "%d. %s...\n   ⏱ Expires: %s\n"
+	listTokensFooter = "\nUse /new_token to create a new token or /revoke_token to revoke one."
+	listTokensKeyLen = 12 // number of key ID characters shown in the listing
+)
+
+// ListTokens retrieves and formats all active API tokens for the specified user.
+// Returns ErrTokenNotFound if the user has no active tokens.
+func (s *Service) ListTokens(ctx context.Context, userID string) (*Response, error) {
+	keys, err := s.repo.GetAPIKeysWithExpiration(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get API keys: %w", err)
+	}
+
+	if len(keys) == 0 {
+		return nil, ErrTokenNotFound
+	}
+
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, listTokensHeader, len(keys), maxTokensPerUser)
+
+	for i, k := range keys {
+		keyDisplay := k.KeyID
+		if len(keyDisplay) > listTokensKeyLen {
+			keyDisplay = keyDisplay[:listTokensKeyLen]
+		}
+
+		expiresAt := k.ExpiresAt.Format(time.DateTime)
+		fmt.Fprintf(&sb, listTokensEntry, i+1, keyDisplay, expiresAt)
+	}
+
+	sb.WriteString(listTokensFooter)
+
+	return &Response{
+		Message: sb.String(),
+	}, nil
+}

--- a/pkg/core/list_tokens_test.go
+++ b/pkg/core/list_tokens_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListTokens(t *testing.T) {
+	tests := []struct {
+		getKeysErr  error
+		expectedErr error
+		checkResp   func(t *testing.T, resp *Response)
+		name        string
+		userID      string
+		keys        []KeyInfo
+	}{
+		{
+			name:        "no tokens",
+			userID:      "user123",
+			keys:        []KeyInfo{},
+			expectedErr: ErrTokenNotFound,
+		},
+		{
+			name:   "single token",
+			userID: "user123",
+			keys: []KeyInfo{
+				{KeyID: "abcdef123456789", ExpiresAt: time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)},
+			},
+			checkResp: func(t *testing.T, resp *Response) {
+				t.Helper()
+				assert.Contains(t, resp.Message, "1/3")
+				assert.Contains(t, resp.Message, "abcdef123456")
+				assert.Contains(t, resp.Message, "2026-03-15")
+			},
+		},
+		{
+			name:   "multiple tokens",
+			userID: "user123",
+			keys: []KeyInfo{
+				{KeyID: "aaabbb123456789", ExpiresAt: time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)},
+				{KeyID: "cccddd987654321", ExpiresAt: time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)},
+				{KeyID: "eeefff111222333", ExpiresAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			checkResp: func(t *testing.T, resp *Response) {
+				t.Helper()
+				assert.Contains(t, resp.Message, "3/3")
+				assert.Contains(t, resp.Message, "aaabbb123456")
+				assert.Contains(t, resp.Message, "cccddd987654")
+				assert.Contains(t, resp.Message, "eeefff111222")
+				assert.Contains(t, resp.Message, "/new_token")
+				assert.Contains(t, resp.Message, "/revoke_token")
+			},
+		},
+		{
+			name:        "get keys error",
+			userID:      "user123",
+			getKeysErr:  errors.New("redis error"),
+			expectedErr: errors.New("failed to get API keys: redis error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := NewMockUserRepo(t)
+			prov := NewMockMITProv(t)
+
+			repo.On("GetAPIKeysWithExpiration", mock.Anything, tt.userID).Return(tt.keys, tt.getKeysErr)
+
+			svc := New(repo, prov)
+
+			resp, err := svc.ListTokens(context.Background(), tt.userID)
+
+			if tt.expectedErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectedErr.Error(), err.Error())
+				assert.Nil(t, resp)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				if tt.checkResp != nil {
+					tt.checkResp(t, resp)
+				}
+			}
+
+			repo.AssertExpectations(t)
+			prov.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/core/revoke_token.go
+++ b/pkg/core/revoke_token.go
@@ -3,25 +3,96 @@ package core
 import (
 	"context"
 	"fmt"
+
+	"github.com/ksysoev/make-it-public-tgbot/pkg/core/conv"
 )
 
-// RevokeToken revokes a user's single existing API token, removing it from both the provider and the repository.
-// Returns an error if multiple or no tokens exist, or if any step in the revocation process fails.
-func (s *Service) RevokeToken(ctx context.Context, userID string) error {
+// RevokeToken revokes a user's API token.
+// If the user has exactly one token, it is revoked directly and nil is returned for the response.
+// If the user has multiple tokens, a conversation is started to ask which token to revoke.
+// Returns an error if no tokens exist or if any step in the process fails.
+func (s *Service) RevokeToken(ctx context.Context, userID string) (*Response, error) {
 	keys, err := s.repo.GetAPIKeys(ctx, userID)
 	if err != nil {
-		return fmt.Errorf("failed to get API keys: %w", err)
+		return nil, fmt.Errorf("failed to get API keys: %w", err)
 	}
 
 	if len(keys) == 0 {
-		return ErrTokenNotFound
+		return nil, ErrTokenNotFound
 	}
 
-	if len(keys) > 1 {
-		return fmt.Errorf("multiple API keys found for user %s, cannot revoke", userID)
+	if len(keys) == 1 {
+		if err := s.revokeKeyByID(ctx, userID, keys[0]); err != nil {
+			return nil, err
+		}
+
+		return nil, nil //nolint:nilnil // nil response signals direct revocation with no follow-up conversation
 	}
 
-	keyID := keys[0]
+	return s.askToSelectTokenForRevocation(ctx, userID)
+}
+
+// askToSelectTokenForRevocation starts a conversation asking the user which of their tokens to revoke.
+func (s *Service) askToSelectTokenForRevocation(ctx context.Context, userID string) (*Response, error) {
+	keys, err := s.repo.GetAPIKeysWithExpiration(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get API keys: %w", err)
+	}
+
+	q := buildTokenSelectionQuestion(keys, "Which token do you want to revoke?")
+
+	c, err := s.repo.GetConversation(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get conversation: %w", err)
+	}
+
+	questions := conv.NewQuestions([]conv.Question{q})
+
+	if err := c.Start(StateSelectTokenToRevoke, questions); err != nil {
+		return nil, fmt.Errorf("failed to start questions: %w", err)
+	}
+
+	current, _ := c.Current()
+
+	if err := s.repo.SaveConversation(ctx, c); err != nil {
+		return nil, fmt.Errorf("failed to save conversation: %w", err)
+	}
+
+	return &Response{
+		Message: current.Text,
+		Answers: current.Answers,
+	}, nil
+}
+
+// handleSelectTokenToRevokeResult processes the user's token selection and performs the revocation.
+func (s *Service) handleSelectTokenToRevokeResult(ctx context.Context, userID string, answers []conv.QuestionAnswer) (*Response, error) {
+	if len(answers) != 1 {
+		return nil, fmt.Errorf("expected exactly one answer for token selection question, got %d", len(answers))
+	}
+
+	selectedPrefix := answers[0].Answer
+
+	keys, err := s.repo.GetAPIKeys(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get API keys: %w", err)
+	}
+
+	keyID, err := resolveKeyIDFromPrefix(keys, selectedPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve key ID: %w", err)
+	}
+
+	if err := s.revokeKeyByID(ctx, userID, keyID); err != nil {
+		return nil, err
+	}
+
+	return &Response{
+		Message: "🔒 Your API token has been successfully revoked.\n\nYou can create a new one using /new_token command.",
+	}, nil
+}
+
+// revokeKeyByID revokes the given key ID from both the provider and the repository.
+func (s *Service) revokeKeyByID(ctx context.Context, userID string, keyID string) error {
 	if err := s.prov.RevokeToken(keyID); err != nil {
 		return fmt.Errorf("failed to revoke token: %w", err)
 	}

--- a/pkg/core/revoke_token_test.go
+++ b/pkg/core/revoke_token_test.go
@@ -4,41 +4,37 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/ksysoev/make-it-public-tgbot/pkg/core/conv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRevokeToken(t *testing.T) {
 	tests := []struct {
-		name          string
-		userID        string
-		existingKeys  []string
 		getKeysErr    error
 		revokeProvErr error
 		revokeRepoErr error
+		expectedResp  *Response
+		name          string
+		userID        string
 		expectedErr   string
+		existingKeys  []string
 	}{
 		{
-			name:         "success",
+			name:         "single token - success",
 			userID:       "user123",
 			existingKeys: []string{"key123"},
-			getKeysErr:   nil,
+			expectedResp: nil, // direct revoke, no conversational response
 			expectedErr:  "",
 		},
 		{
 			name:         "no API keys found",
 			userID:       "user123",
 			existingKeys: []string{},
-			getKeysErr:   nil,
 			expectedErr:  ErrTokenNotFound.Error(),
-		},
-		{
-			name:         "multiple API keys found",
-			userID:       "user123",
-			existingKeys: []string{"key123", "key456"},
-			getKeysErr:   nil,
-			expectedErr:  "multiple API keys found for user user123, cannot revoke",
 		},
 		{
 			name:         "get keys error",
@@ -48,7 +44,14 @@ func TestRevokeToken(t *testing.T) {
 			expectedErr:  "failed to get API keys: get keys error",
 		},
 		{
-			name:          "revoke from repository error",
+			name:          "single token - revoke provider error",
+			userID:        "user123",
+			existingKeys:  []string{"key123"},
+			revokeProvErr: errors.New("revoke provider error"),
+			expectedErr:   "failed to revoke token: revoke provider error",
+		},
+		{
+			name:          "single token - revoke repository error",
 			userID:        "user123",
 			existingKeys:  []string{"key123"},
 			revokeRepoErr: errors.New("revoke repository error"),
@@ -63,24 +66,115 @@ func TestRevokeToken(t *testing.T) {
 
 			repo.On("GetAPIKeys", mock.Anything, tt.userID).Return(tt.existingKeys, tt.getKeysErr)
 
-			if len(tt.existingKeys) == 1 {
+			if len(tt.existingKeys) == 1 && tt.getKeysErr == nil {
 				prov.On("RevokeToken", tt.existingKeys[0]).Return(tt.revokeProvErr)
-				repo.On("RevokeToken", mock.Anything, tt.userID, tt.existingKeys[0]).Return(tt.revokeRepoErr)
+
+				if tt.revokeProvErr == nil {
+					repo.On("RevokeToken", mock.Anything, tt.userID, tt.existingKeys[0]).Return(tt.revokeRepoErr)
+				}
 			}
 
 			svc := New(repo, prov)
 
-			err := svc.RevokeToken(context.Background(), tt.userID)
+			resp, err := svc.RevokeToken(context.Background(), tt.userID)
 
 			if tt.expectedErr != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, tt.expectedErr, err.Error())
+				assert.Nil(t, resp)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedResp, resp)
 			}
 
 			repo.AssertExpectations(t)
 			prov.AssertExpectations(t)
 		})
 	}
+}
+
+func TestRevokeToken_MultipleKeys(t *testing.T) {
+	userID := "user123"
+	keys := []KeyInfo{
+		{KeyID: "abcdef1234", ExpiresAt: time.Now().Add(24 * time.Hour)},
+		{KeyID: "xyz9876543", ExpiresAt: time.Now().Add(48 * time.Hour)},
+	}
+
+	repo := NewMockUserRepo(t)
+	prov := NewMockMITProv(t)
+
+	repo.On("GetAPIKeys", mock.Anything, userID).Return([]string{"abcdef1234", "xyz9876543"}, nil)
+	repo.On("GetAPIKeysWithExpiration", mock.Anything, userID).Return(keys, nil)
+	repo.On("GetConversation", mock.Anything, userID).Return(conv.New(userID), nil)
+	repo.On("SaveConversation", mock.Anything, mock.MatchedBy(func(c *conv.Conversation) bool {
+		return c.ID == userID && c.State == StateSelectTokenToRevoke
+	})).Return(nil)
+
+	svc := New(repo, prov)
+
+	resp, err := svc.RevokeToken(context.Background(), userID)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "Which token do you want to revoke?", resp.Message)
+	assert.Len(t, resp.Answers, 2)
+
+	repo.AssertExpectations(t)
+	prov.AssertExpectations(t)
+}
+
+func TestHandleSelectTokenToRevokeResult(t *testing.T) {
+	userID := "user123"
+	keyID := "abcdef123456"
+
+	t.Run("success", func(t *testing.T) {
+		repo := NewMockUserRepo(t)
+		prov := NewMockMITProv(t)
+
+		repo.On("GetAPIKeys", mock.Anything, userID).Return([]string{keyID}, nil)
+		prov.On("RevokeToken", keyID).Return(nil)
+		repo.On("RevokeToken", mock.Anything, userID, keyID).Return(nil)
+
+		svc := New(repo, prov)
+
+		answers := []conv.QuestionAnswer{
+			{Answer: keyID[:keyIDDisplayLen] + " (exp: 2026-03-01)"},
+		}
+
+		resp, err := svc.handleSelectTokenToRevokeResult(context.Background(), userID, answers)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Contains(t, resp.Message, "revoked")
+
+		repo.AssertExpectations(t)
+		prov.AssertExpectations(t)
+	})
+
+	t.Run("wrong number of answers", func(t *testing.T) {
+		svc := New(NewMockUserRepo(t), NewMockMITProv(t))
+
+		_, err := svc.handleSelectTokenToRevokeResult(context.Background(), userID, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected exactly one answer")
+	})
+
+	t.Run("key not found", func(t *testing.T) {
+		repo := NewMockUserRepo(t)
+		prov := NewMockMITProv(t)
+
+		repo.On("GetAPIKeys", mock.Anything, userID).Return([]string{"different123456"}, nil)
+
+		svc := New(repo, prov)
+
+		answers := []conv.QuestionAnswer{
+			{Answer: "nomatch1 (exp: 2026-03-01)"},
+		}
+
+		_, err := svc.handleSelectTokenToRevokeResult(context.Background(), userID, answers)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to resolve key ID")
+
+		repo.AssertExpectations(t)
+	})
 }

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -10,13 +10,14 @@ import (
 )
 
 var (
-	ErrMaxTokensExceeded = fmt.Errorf("maximum tokens exceeded")
-	ErrTokenNotFound     = fmt.Errorf("token not found")
+	ErrTokenNotFound = fmt.Errorf("token not found")
 )
 
+// UserRepo defines the storage operations required by the core service.
 type UserRepo interface {
 	AddAPIKey(ctx context.Context, userID string, apiKeyID string, expiresIn time.Duration) error
 	GetAPIKeys(ctx context.Context, userID string) ([]string, error)
+	GetAPIKeysWithExpiration(ctx context.Context, userID string) ([]KeyInfo, error)
 	RevokeToken(ctx context.Context, userID string, apiKeyID string) error
 	SaveConversation(ctx context.Context, conversation *conv.Conversation) error
 	GetConversation(ctx context.Context, conversationID string) (*conv.Conversation, error)
@@ -99,6 +100,10 @@ func (s *Service) HandleMessage(ctx context.Context, userID string, message stri
 		return s.handleNewTokenResult(ctx, userID, res)
 	case StateTokenRegenerate:
 		return s.handleTokenRegenerateResult(ctx, userID, res)
+	case StateSelectTokenToRegenerate:
+		return s.handleSelectTokenToRegenerateResult(ctx, userID, res)
+	case StateSelectTokenToRevoke:
+		return s.handleSelectTokenToRevokeResult(ctx, userID, res)
 	default:
 		return nil, fmt.Errorf("unsupported conversation state: %s", state)
 	}

--- a/pkg/core/token.go
+++ b/pkg/core/token.go
@@ -2,8 +2,15 @@ package core
 
 import "time"
 
+// APIToken holds the details of a newly generated API token.
 type APIToken struct {
 	KeyID     string
 	Token     string
 	ExpiresIn time.Duration
+}
+
+// KeyInfo holds the display information for an existing API key.
+type KeyInfo struct {
+	ExpiresAt time.Time
+	KeyID     string
 }

--- a/pkg/core/user_repo_mock.go
+++ b/pkg/core/user_repo_mock.go
@@ -181,6 +181,65 @@ func (_c *MockUserRepo_GetAPIKeys_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
+// GetAPIKeysWithExpiration provides a mock function with given fields: ctx, userID
+func (_m *MockUserRepo) GetAPIKeysWithExpiration(ctx context.Context, userID string) ([]KeyInfo, error) {
+	ret := _m.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAPIKeysWithExpiration")
+	}
+
+	var r0 []KeyInfo
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) ([]KeyInfo, error)); ok {
+		return rf(ctx, userID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) []KeyInfo); ok {
+		r0 = rf(ctx, userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]KeyInfo)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockUserRepo_GetAPIKeysWithExpiration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAPIKeysWithExpiration'
+type MockUserRepo_GetAPIKeysWithExpiration_Call struct {
+	*mock.Call
+}
+
+// GetAPIKeysWithExpiration is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *MockUserRepo_Expecter) GetAPIKeysWithExpiration(ctx interface{}, userID interface{}) *MockUserRepo_GetAPIKeysWithExpiration_Call {
+	return &MockUserRepo_GetAPIKeysWithExpiration_Call{Call: _e.mock.On("GetAPIKeysWithExpiration", ctx, userID)}
+}
+
+func (_c *MockUserRepo_GetAPIKeysWithExpiration_Call) Run(run func(ctx context.Context, userID string)) *MockUserRepo_GetAPIKeysWithExpiration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockUserRepo_GetAPIKeysWithExpiration_Call) Return(_a0 []KeyInfo, _a1 error) *MockUserRepo_GetAPIKeysWithExpiration_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockUserRepo_GetAPIKeysWithExpiration_Call) RunAndReturn(run func(context.Context, string) ([]KeyInfo, error)) *MockUserRepo_GetAPIKeysWithExpiration_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetConversation provides a mock function with given fields: ctx, conversationID
 func (_m *MockUserRepo) GetConversation(ctx context.Context, conversationID string) (*conv.Conversation, error) {
 	ret := _m.Called(ctx, conversationID)

--- a/pkg/prov/mit.go
+++ b/pkg/prov/mit.go
@@ -16,9 +16,9 @@ type Config struct {
 }
 
 type MIT struct {
-	defaultTTL int64
-	baseUrl    string
 	cl         *http.Client
+	baseUrl    string
+	defaultTTL int64
 }
 
 // New creates and returns a new instance of the MIT struct initialized with the provided configuration.

--- a/pkg/prov/mit_test.go
+++ b/pkg/prov/mit_test.go
@@ -27,11 +27,11 @@ func TestNew(t *testing.T) {
 
 func TestGenerateToken(t *testing.T) {
 	tests := []struct {
-		name           string
-		defaultTTL     int64
 		serverResponse func(w http.ResponseWriter, r *http.Request)
 		expectedToken  *core.APIToken
+		name           string
 		expectedError  string
+		defaultTTL     int64
 	}{
 		{
 			name:       "success",


### PR DESCRIPTION
## Summary

- Allow users to hold up to 3 API tokens simultaneously (previously 1)
- Add `/my_tokens` command to list all active tokens with key ID previews and expiration dates
- Rework `/new_token`: when at the 3-token limit, start a conversation to pick an existing token to regenerate (revoke old + create new with same key ID)
- Rework `/revoke_token`: with multiple tokens, start a conversation to select which one to revoke; with a single token, revoke directly as before

## Changes

### New functionality
- `pkg/core/list_tokens.go` — `ListTokens()` formats all active tokens for display
- `pkg/core/create_token.go` — multi-token flows: at-limit regeneration conversation, token selection question, `Field` on expiration question carries the key ID to revoke through the conversation
- `pkg/core/revoke_token.go` — returns `(*Response, error)`; direct revoke for 1 token, conversational selection for 2–3
- `pkg/bot/handlers.go` — `/my_tokens` handler, updated `/revoke_token` for new signature, updated help/welcome text

### Infrastructure
- `pkg/core/conv/conv.go` — added `Field string` to `Question` struct
- `pkg/core/conv/questions.go` — `ProcessAnswer` copies `Question.Field → QuestionAnswer.Field`
- `pkg/repo/user.go` — added `GetAPIKeysWithExpiration()` using `ZRangeByScoreWithScores`
- Mocks regenerated via `make mocks`

### Tests & quality
- All new flows covered by unit tests; all packages pass (`GOWORK=off go test ./...`)
- `golangci-lint` passes with 0 issues
- Fixed `TestGetAPIKeysWithExpiration` to use past-score insertion instead of `FastForward` (Go wall-clock time does not advance with miniredis fast-forward)