### PR TITLE
Disable multi arch build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
   deploy:
     needs: build


### PR DESCRIPTION
This pull request makes minor adjustments to the Docker workflow configuration to simplify the build process for pull requests. The most important changes are related to platform targeting and setup steps.

Docker build process simplification:

* The `platforms` parameter for the Docker build step is now always set to `'linux/amd64'`, rather than conditionally including `linux/arm64` for non-pull request events.
* The QEMU setup step, which enabled multi-platform builds, has been removed from the workflow.